### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Cancel any currently running workflows from the same PR, branch, or
+# tag when a new workflow is triggered.
+#
+# https://stackoverflow.com/a/66336834
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  all:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          target: riscv32imc-unknown-none-elf
+          toolchain: nightly-2023-03-09
+          components: rust-src
+      - uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          ldproxy: false
+          override: false
+      - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: 1.13.0
+
+      - name: check
+        run: just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           target: riscv32imc-unknown-none-elf
           toolchain: nightly-2023-03-09
-          components: rust-src
+          components: rust-src,rustfmt
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
           ldproxy: false

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+export SSID := "Dummy"
+export PASSWORD := "Dummy"
+
+all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly")
+    cd esp-mbedtls && cargo fmt --all -- --check
+    
+[private]
+check target toolchain:
+    cd examples-{{ target }} && cargo +{{ toolchain }} check --example sync
+    cd examples-{{ target }} && cargo +{{ toolchain }} check --example sync_client
+    cd examples-{{ target }} && cargo +{{ toolchain }} check --example async --features=async
+    cd examples-{{ target }} && cargo +{{ toolchain }} check --example async_client --features=async
+    cd examples-{{ target }} && cargo fmt --all -- --check

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ export SSID := "Dummy"
 export PASSWORD := "Dummy"
 
 all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-2023-03-09")
-    cd esp-mbedtls && cargo fmt --all -- --check
+    cd esp-mbedtls && cargo +nightly-2023-03-09 fmt --all -- --check
     
 [private]
 check target toolchain:
@@ -10,4 +10,4 @@ check target toolchain:
     cd examples-{{ target }} && cargo +{{ toolchain }} check --example sync_client
     cd examples-{{ target }} && cargo +{{ toolchain }} check --example async --features=async
     cd examples-{{ target }} && cargo +{{ toolchain }} check --example async_client --features=async
-    cd examples-{{ target }} && cargo fmt --all -- --check
+    cd examples-{{ target }} && cargo +{{ toolchain }} fmt --all -- --check

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 export SSID := "Dummy"
 export PASSWORD := "Dummy"
 
-all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly")
+all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-2023-03-09")
     cd esp-mbedtls && cargo fmt --all -- --check
     
 [private]


### PR DESCRIPTION
This adds CI.

I tried something new here: Using a `justfile` to run the actual checks and use as-little-as-possible of GitHub Actions

- good: this makes it really easy to do the same checks locally (just use `just`)
- downside: it's harder to see at a glance what exactly failed
- downside: if the job fails, rerunning means rerunning everything

I'd like to experiment with this a bit since the first point is really something I'd like to have - maybe there are even solutions for the other two points
