### PR TITLE
Ensure that certificates are null terminated

### DIFF
--- a/esp-mbedtls/src/compat.rs
+++ b/esp-mbedtls/src/compat.rs
@@ -180,3 +180,21 @@ impl core::fmt::Write for StrBuf {
         Ok(())
     }
 }
+
+pub(crate) fn ensure_null_terminated(s: &str) -> (*const u8, u32) {
+    let bytes = s.as_bytes();
+
+    // String is already null-terminated
+    if bytes.last() == Some(&0) {
+        (s.as_ptr(), s.len() as u32)
+    } else {
+        // Create a new null-terminated string from bytes
+        let mut buffer = [0; 4096];
+        // Get the min between buffer or string
+        let len = core::cmp::min(bytes.len(), buffer.len() - 1);
+        buffer[..len].copy_from_slice(&bytes[..len]);
+        buffer[len] = 0;
+        // Bump len by 1, since we added a null terminating character
+        (buffer.as_ptr(), (len + 1) as u32)
+    }
+}

--- a/esp-mbedtls/src/compat.rs
+++ b/esp-mbedtls/src/compat.rs
@@ -180,21 +180,3 @@ impl core::fmt::Write for StrBuf {
         Ok(())
     }
 }
-
-pub(crate) fn ensure_null_terminated(s: &str) -> (*const u8, u32) {
-    let bytes = s.as_bytes();
-
-    // String is already null-terminated
-    if bytes.last() == Some(&0) {
-        (s.as_ptr(), s.len() as u32)
-    } else {
-        // Create a new null-terminated string from bytes
-        let mut buffer = [0; 4096];
-        // Get the min between buffer or string
-        let len = core::cmp::min(bytes.len(), buffer.len() - 1);
-        buffer[..len].copy_from_slice(&bytes[..len]);
-        buffer[len] = 0;
-        // Bump len by 1, since we added a null terminating character
-        (buffer.as_ptr(), (len + 1) as u32)
-    }
-}

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -104,7 +104,6 @@ pub fn set_debug(level: u32) {
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct X509<'a> {
-
     /// The certificate in bytes
     bytes: &'a [u8],
 
@@ -113,7 +112,6 @@ pub struct X509<'a> {
 }
 
 impl<'a> X509<'a> {
-
     /// Reads certificate in pem format from bytes
     ///
     /// # Error
@@ -136,7 +134,10 @@ impl<'a> X509<'a> {
     /// *Note*: This function assumes that the size of the size is the exact
     /// length of the certificate
     pub fn der(bytes: &'a [u8]) -> Self {
-        Self { bytes, len: bytes.len() }
+        Self {
+            bytes,
+            len: bytes.len(),
+        }
     }
 
     /// Returns the bytes of the certificate
@@ -301,7 +302,7 @@ impl<'a> Certificates<'a> {
                 error_checked!(mbedtls_x509_crt_parse(
                     client_crt,
                     client_cert.as_ptr(),
-                    client_cert.len() as u32
+                    client_cert.len() as u32,
                 ))?;
 
                 // Client key

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -15,8 +15,6 @@ use embedded_io::Io;
 use esp_mbedtls_sys::bindings::*;
 use esp_mbedtls_sys::c_types::*;
 
-use crate::compat::ensure_null_terminated;
-
 // these will come from esp-wifi (i.e. this can only be used together with esp-wifi)
 extern "C" {
     fn free(ptr: *const u8);

--- a/examples-esp32/examples/async.rs
+++ b/examples-esp32/examples/async.rs
@@ -10,6 +10,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
+use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
@@ -172,7 +173,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
         Mode::Client,
         TlsVersion::Tls1_3,
         Certificates {
-            certs: Some(CERT),
+            certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
             ..Default::default()
         },
     )

--- a/examples-esp32/examples/async_client.rs
+++ b/examples-esp32/examples/async_client.rs
@@ -10,8 +10,8 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
-use esp_mbedtls::Certificates;
 use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
+use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
 use esp_wifi::initialize;
@@ -169,17 +169,17 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT),
-        client_key: Some(PRIVATE_KEY),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY.as_bytes()).unwrap()),
         password: None,
     };
 
     #[cfg(feature = "encrypted_private_key")]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT_WITH_PASSWORD),
-        client_key: Some(PRIVATE_KEY_WITH_PASSWORD),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT_WITH_PASSWORD.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY_WITH_PASSWORD.as_bytes()).unwrap()),
         password: Some("password\0"),
     };
 

--- a/examples-esp32/examples/sync.rs
+++ b/examples-esp32/examples/sync.rs
@@ -8,7 +8,7 @@ use embedded_svc::{
 };
 use esp_backtrace as _;
 use esp_mbedtls::{set_debug, Mode, TlsVersion};
-use esp_mbedtls::{Certificates, Session};
+use esp_mbedtls::{Certificates, Session, X509};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     current_millis,
@@ -112,7 +112,7 @@ fn main() -> ! {
         Mode::Client,
         TlsVersion::Tls1_3,
         Certificates {
-            certs: Some(CERT),
+            certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
             ..Default::default()
         },
     )

--- a/examples-esp32/examples/sync_client.rs
+++ b/examples-esp32/examples/sync_client.rs
@@ -7,7 +7,7 @@ use embedded_svc::{
     wifi::{ClientConfiguration, Configuration, Wifi},
 };
 use esp_backtrace as _;
-use esp_mbedtls::{set_debug, Mode, TlsVersion};
+use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
@@ -108,17 +108,17 @@ fn main() -> ! {
 
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT),
-        client_key: Some(PRIVATE_KEY),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY.as_bytes()).unwrap()),
         password: None,
     };
 
     #[cfg(feature = "encrypted_private_key")]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT_WITH_PASSWORD),
-        client_key: Some(PRIVATE_KEY_WITH_PASSWORD),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT_WITH_PASSWORD.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY_WITH_PASSWORD.as_bytes()).unwrap()),
         password: Some("password\0"),
     };
 

--- a/examples-esp32c3/examples/async.rs
+++ b/examples-esp32c3/examples/async.rs
@@ -10,6 +10,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
+use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
@@ -169,7 +170,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
         Mode::Client,
         TlsVersion::Tls1_3,
         Certificates {
-            certs: Some(CERT),
+            certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
             ..Default::default()
         },
     )

--- a/examples-esp32c3/examples/async_client.rs
+++ b/examples-esp32c3/examples/async_client.rs
@@ -10,8 +10,8 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
-use esp_mbedtls::Certificates;
 use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
+use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
 use esp_wifi::initialize;
@@ -166,17 +166,17 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT),
-        client_key: Some(PRIVATE_KEY),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY.as_bytes()).unwrap()),
         password: None,
     };
 
     #[cfg(feature = "encrypted_private_key")]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT_WITH_PASSWORD),
-        client_key: Some(PRIVATE_KEY_WITH_PASSWORD),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT_WITH_PASSWORD.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY_WITH_PASSWORD.as_bytes()).unwrap()),
         password: Some("password\0"),
     };
 

--- a/examples-esp32c3/examples/sync.rs
+++ b/examples-esp32c3/examples/sync.rs
@@ -7,7 +7,7 @@ use embedded_svc::{
     wifi::{ClientConfiguration, Configuration, Wifi},
 };
 use esp_backtrace as _;
-use esp_mbedtls::{set_debug, Mode, TlsVersion};
+use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
@@ -113,7 +113,7 @@ fn main() -> ! {
         Mode::Client,
         TlsVersion::Tls1_3,
         Certificates {
-            certs: Some(CERT),
+            certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
             ..Default::default()
         },
     )

--- a/examples-esp32c3/examples/sync_client.rs
+++ b/examples-esp32c3/examples/sync_client.rs
@@ -7,7 +7,7 @@ use embedded_svc::{
     wifi::{ClientConfiguration, Configuration, Wifi},
 };
 use esp_backtrace as _;
-use esp_mbedtls::{set_debug, Mode, TlsVersion};
+use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
@@ -109,17 +109,17 @@ fn main() -> ! {
 
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT),
-        client_key: Some(PRIVATE_KEY),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY.as_bytes()).unwrap()),
         password: None,
     };
 
     #[cfg(feature = "encrypted_private_key")]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT_WITH_PASSWORD),
-        client_key: Some(PRIVATE_KEY_WITH_PASSWORD),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT_WITH_PASSWORD.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY_WITH_PASSWORD.as_bytes()).unwrap()),
         password: Some("password\0"),
     };
 

--- a/examples-esp32s3/examples/async.rs
+++ b/examples-esp32s3/examples/async.rs
@@ -10,6 +10,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
+use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
@@ -172,7 +173,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
         Mode::Client,
         TlsVersion::Tls1_3,
         Certificates {
-            certs: Some(CERT),
+            certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
             ..Default::default()
         },
     )

--- a/examples-esp32s3/examples/async_client.rs
+++ b/examples-esp32s3/examples/async_client.rs
@@ -10,8 +10,8 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
-use esp_mbedtls::{Certificates, X509};
 use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
+use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
 use esp_wifi::initialize;
@@ -167,23 +167,19 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     set_debug(0);
 
-    let cert = X509::pem(CERT.as_bytes()).unwrap();
-    let client_cert = X509::pem(CLIENT_CERT.as_bytes()).unwrap();
-    let client_key = X509::pem(PRIVATE_KEY.as_bytes()).unwrap();
-
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(cert),
-        client_cert: Some(client_cert),
-        client_key: Some(client_key),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY.as_bytes()).unwrap()),
         password: None,
     };
 
     #[cfg(feature = "encrypted_private_key")]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT_WITH_PASSWORD),
-        client_key: Some(PRIVATE_KEY_WITH_PASSWORD),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT_WITH_PASSWORD.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY_WITH_PASSWORD.as_bytes()).unwrap()),
         password: Some("password\0"),
     };
 

--- a/examples-esp32s3/examples/async_client.rs
+++ b/examples-esp32s3/examples/async_client.rs
@@ -10,7 +10,7 @@ use embassy_executor::Executor;
 use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
-use esp_mbedtls::Certificates;
+use esp_mbedtls::{Certificates, X509};
 use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
@@ -167,11 +167,15 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     set_debug(0);
 
+    let cert = X509::pem(CERT.as_bytes()).unwrap();
+    let client_cert = X509::pem(CLIENT_CERT.as_bytes()).unwrap();
+    let client_key = X509::pem(PRIVATE_KEY.as_bytes()).unwrap();
+
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT),
-        client_key: Some(PRIVATE_KEY),
+        certs: Some(cert),
+        client_cert: Some(client_cert),
+        client_key: Some(client_key),
         password: None,
     };
 

--- a/examples-esp32s3/examples/sync.rs
+++ b/examples-esp32s3/examples/sync.rs
@@ -7,7 +7,7 @@ use embedded_svc::{
     wifi::{ClientConfiguration, Configuration, Wifi},
 };
 use esp_backtrace as _;
-use esp_mbedtls::{set_debug, Mode, TlsVersion};
+use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
@@ -112,7 +112,7 @@ fn main() -> ! {
         Mode::Client,
         TlsVersion::Tls1_3,
         Certificates {
-            certs: Some(CERT),
+            certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
             ..Default::default()
         },
     )

--- a/examples-esp32s3/examples/sync_client.rs
+++ b/examples-esp32s3/examples/sync_client.rs
@@ -7,7 +7,7 @@ use embedded_svc::{
     wifi::{ClientConfiguration, Configuration, Wifi},
 };
 use esp_backtrace as _;
-use esp_mbedtls::{set_debug, Mode, TlsVersion};
+use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
@@ -108,17 +108,17 @@ fn main() -> ! {
 
     #[cfg(not(feature = "encrypted_private_key"))]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT),
-        client_key: Some(PRIVATE_KEY),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY.as_bytes()).unwrap()),
         password: None,
     };
 
     #[cfg(feature = "encrypted_private_key")]
     let certificates = Certificates {
-        certs: Some(CERT),
-        client_cert: Some(CLIENT_CERT_WITH_PASSWORD),
-        client_key: Some(PRIVATE_KEY_WITH_PASSWORD),
+        certs: Some(X509::pem(CERT.as_bytes()).unwrap()),
+        client_cert: Some(X509::pem(CLIENT_CERT_WITH_PASSWORD.as_bytes()).unwrap()),
+        client_key: Some(X509::pem(PRIVATE_KEY_WITH_PASSWORD.as_bytes()).unwrap()),
         password: Some("password\0"),
     };
 


### PR DESCRIPTION
This is a quality of life PR.

Mbedtls requires that certificates and passwords passed to it are null terminated `\0`, like C strings.  

This new helper checks if the certificates are null-terminated, and if not, it adds the nullish terminator.

This allow to include certificates using `include_str!()` without having to append `\0` ourselves, since the library takes care of it.