### PR TITLE
Add #[derive] attributes to certificates

### DIFF
--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -102,7 +102,7 @@ pub fn set_debug(level: u32) {
 /// const CERTIFICATE: &[u8] = include_bytes!("certificate.der");
 /// let cert = X509::der(CERTIFICATE);
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct X509<'a>(&'a [u8]);
 
 impl<'a> X509<'a> {
@@ -150,6 +150,7 @@ impl<'a> X509<'a> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Certificates<'a> {
     pub certs: Option<X509<'a>>,
     pub client_cert: Option<X509<'a>>,

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -454,7 +454,7 @@ impl<T> Drop for Session<T> {
     fn drop(&mut self) {
         log::debug!("session dropped - freeing memory");
         unsafe {
-            error_checked!(mbedtls_ssl_close_notify(self.ssl_context)).unwrap();
+            mbedtls_ssl_close_notify(self.ssl_context);
             mbedtls_ssl_config_free(self.ssl_config);
             mbedtls_ssl_free(self.ssl_context);
             mbedtls_x509_crt_free(self.crt);
@@ -566,7 +566,7 @@ pub mod asynch {
         fn drop(&mut self) {
             log::debug!("session dropped - freeing memory");
             unsafe {
-                error_checked!(mbedtls_ssl_close_notify(self.ssl_context)).unwrap();
+                mbedtls_ssl_close_notify(self.ssl_context);
                 mbedtls_ssl_config_free(self.ssl_config);
                 mbedtls_ssl_free(self.ssl_context);
                 mbedtls_x509_crt_free(self.crt);


### PR DESCRIPTION
Add useful #[derive] attributes to certificates, like copy, which allows to reuse the certificates after creating a new session.