### PR TITLE
Update esp-wifi and esp-hal

### DIFF
--- a/examples-esp32/Cargo.toml
+++ b/examples-esp32/Cargo.toml
@@ -7,7 +7,16 @@ license = "MIT OR Apache-2.0"
 
 [profile.release]
 debug = true
-lto = "off"
+lto = false
+
+[profile.release.package.esp-wifi]
+opt-level = 3
+
+[profile.dev]
+lto = false
+
+[profile.dev.package.esp-wifi]
+opt-level = 3
 
 [dependencies]
 hal = { package = "esp32-hal", version = "0.12.0" }

--- a/examples-esp32/Cargo.toml
+++ b/examples-esp32/Cargo.toml
@@ -10,17 +10,17 @@ debug = true
 lto = "off"
 
 [dependencies]
-hal = { package = "esp32-hal", version = "0.11.0" }
+hal = { package = "esp32-hal", version = "0.12.0" }
 esp-backtrace = { version = "0.6.0", features = ["esp32", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.4.0", features = ["esp32","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"], optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "26474ce6eb759e5add1c137f3417845e0797df3a", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
+embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32", "embedded-svc", "wifi"], rev = "a01d075c64ddf777920344936f8bdaaddf7de288" }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
 smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
-embedded-svc = { version = "0.23.1", default-features = false}
+embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"
 embedded-hal = "0.2"
 embedded-io = "0.4.0"
@@ -34,10 +34,7 @@ name              = "async"
 required-features = ["async"]
 
 [features]
-async = ["esp-wifi/esp32-async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
+async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
 # Use this feature to enable the private key with a password
 encrypted_private_key = []
 
-[patch.crates-io]
-esp32-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32-hal", rev = "e5d1c603b0d4833632c2358ad3fad36964bf0ed5"}
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", package = "esp-hal-common", rev = "e5d1c603b0d4833632c2358ad3fad36964bf0ed5"}

--- a/examples-esp32/Cargo.toml
+++ b/examples-esp32/Cargo.toml
@@ -19,16 +19,16 @@ lto = false
 opt-level = 3
 
 [dependencies]
-hal = { package = "esp32-hal", version = "0.12.0" }
+hal = { package = "esp32-hal", version = "0.13.0" }
 esp-backtrace = { version = "0.6.0", features = ["esp32", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.4.0", features = ["esp32","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
 embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
-smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32", "embedded-svc", "wifi"], rev = "68dc11bbb2c0efa29c4acbbf134d6f142441065e" }
+smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"
 embedded-hal = "0.2"
@@ -43,7 +43,7 @@ name              = "async"
 required-features = ["async"]
 
 [features]
-async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
+async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async", "hal/embassy-time-timg0"]
 # Use this feature to enable the private key with a password
 encrypted_private_key = []
 

--- a/examples-esp32/examples/async.rs
+++ b/examples-esp32/examples/async.rs
@@ -14,8 +14,8 @@ use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::initialize;
 use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -53,7 +53,8 @@ fn main() -> ! {
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.timer0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
@@ -62,7 +63,7 @@ fn main() -> ! {
     .unwrap();
 
     let (wifi, _) = peripherals.RADIO.split();
-    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(wifi, WifiMode::Sta);
+    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta);
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/examples-esp32/examples/async.rs
+++ b/examples-esp32/examples/async.rs
@@ -72,7 +72,7 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -147,7 +147,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -156,7 +156,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(Duration::from_secs(10)));
 
     let remote_endpoint = (Ipv4Address::new(142, 250, 185, 68), 443); // www.google.com
     println!("connecting...");

--- a/examples-esp32/examples/async_client.rs
+++ b/examples-esp32/examples/async_client.rs
@@ -72,7 +72,7 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -147,7 +147,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -156,7 +156,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(Duration::from_secs(10)));
 
     let remote_endpoint = (Ipv4Address::new(62, 210, 201, 125), 443); // certauth.cryptomix.com
     println!("connecting...");

--- a/examples-esp32/examples/async_client.rs
+++ b/examples-esp32/examples/async_client.rs
@@ -14,8 +14,8 @@ use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
 use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::initialize;
 use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -53,7 +53,8 @@ fn main() -> ! {
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.timer0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
@@ -62,7 +63,7 @@ fn main() -> ! {
     .unwrap();
 
     let (wifi, _) = peripherals.RADIO.split();
-    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(wifi, WifiMode::Sta);
+    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta);
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/examples-esp32/examples/sync.rs
+++ b/examples-esp32/examples/sync.rs
@@ -14,6 +14,7 @@ use esp_wifi::{
     current_millis,
     wifi::{utils::create_network_interface, WifiMode},
     wifi_interface::WifiStack,
+    EspWifiInitFor,
 };
 use hal::timer::TimerGroup;
 use hal::{
@@ -22,7 +23,7 @@ use hal::{
     prelude::*,
     Rng, Rtc,
 };
-use smoltcp::{iface::SocketStorage, wire::Ipv4Address};
+use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -40,19 +41,26 @@ fn main() -> ! {
     // Disable watchdog timers
     rtc.rwdt.disable();
 
-    let (wifi, _) = peripherals.RADIO.split();
-    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(wifi, WifiMode::Sta, &mut socket_set_entries);
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
-
     let rngp = Rng::new(peripherals.RNG);
     let timer = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    esp_wifi::initialize(timer.timer0, rngp, system.radio_clock_control, &clocks).unwrap();
+    let init = esp_wifi::initialize(
+        EspWifiInitFor::Wifi,
+        timer.timer0,
+        rngp,
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let (wifi, _) = peripherals.RADIO.split();
+    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries);
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
@@ -101,7 +109,7 @@ fn main() -> ! {
     socket.work();
 
     socket
-        .open(Ipv4Address::new(142, 250, 185, 68), 443) // google.com
+        .open(IpAddress::v4(142, 250, 185, 68), 443) // google.com
         .unwrap();
 
     set_debug(0);

--- a/examples-esp32/examples/sync_client.rs
+++ b/examples-esp32/examples/sync_client.rs
@@ -14,6 +14,7 @@ use esp_wifi::{
     current_millis,
     wifi::{utils::create_network_interface, WifiMode},
     wifi_interface::WifiStack,
+    EspWifiInitFor,
 };
 use hal::timer::TimerGroup;
 use hal::{
@@ -22,7 +23,7 @@ use hal::{
     prelude::*,
     Rng, Rtc,
 };
-use smoltcp::{iface::SocketStorage, wire::Ipv4Address};
+use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -40,19 +41,26 @@ fn main() -> ! {
     // Disable watchdog timers
     rtc.rwdt.disable();
 
-    let (wifi, _) = peripherals.RADIO.split();
-    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(wifi, WifiMode::Sta, &mut socket_set_entries);
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
-
     let rngp = Rng::new(peripherals.RNG);
     let timer = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    esp_wifi::initialize(timer.timer0, rngp, system.radio_clock_control, &clocks).unwrap();
+    let init = esp_wifi::initialize(
+        EspWifiInitFor::Wifi,
+        timer.timer0,
+        rngp,
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let (wifi, _) = peripherals.RADIO.split();
+    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries);
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
@@ -101,7 +109,7 @@ fn main() -> ! {
     socket.work();
 
     socket
-        .open(Ipv4Address::new(62, 210, 201, 125), 443) // certauth.cryptomix.com
+        .open(IpAddress::v4(62, 210, 201, 125), 443) // certauth.cryptomix.com
         .unwrap();
 
     set_debug(0);

--- a/examples-esp32c3/Cargo.toml
+++ b/examples-esp32c3/Cargo.toml
@@ -7,6 +7,16 @@ license = "MIT OR Apache-2.0"
 
 [profile.release]
 debug = true
+lto = false
+
+[profile.release.package.esp-wifi]
+opt-level = 3
+
+[profile.dev]
+lto = false
+
+[profile.dev.package.esp-wifi]
+opt-level = 3
 
 [dependencies]
 hal = { package = "esp32c3-hal", version = "0.9.0" }

--- a/examples-esp32c3/Cargo.toml
+++ b/examples-esp32c3/Cargo.toml
@@ -24,7 +24,7 @@ esp-backtrace = { version = "0.6.0", features = ["esp32c3", "panic-handler", "pr
 esp-println       = { version = "0.4.0", features = ["esp32c3","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
-embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
+embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-riscv32"], optional = true }
 embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
 esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32c3", "embedded-svc", "wifi"], rev = "68dc11bbb2c0efa29c4acbbf134d6f142441065e" }

--- a/examples-esp32c3/Cargo.toml
+++ b/examples-esp32c3/Cargo.toml
@@ -19,16 +19,16 @@ lto = false
 opt-level = 3
 
 [dependencies]
-hal = { package = "esp32c3-hal", version = "0.9.0" }
+hal = { package = "esp32c3-hal", version = "0.10.0" }
 esp-backtrace = { version = "0.6.0", features = ["esp32c3", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.4.0", features = ["esp32c3","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
 embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32c3", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
-smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32c3", "embedded-svc", "wifi"], rev = "68dc11bbb2c0efa29c4acbbf134d6f142441065e" }
+smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"
 embedded-hal = "0.2"
@@ -43,7 +43,7 @@ name              = "async"
 required-features = ["async"]
 
 [features]
-async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
+async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async", "hal/embassy-time-timg0"]
 # Use this feature to enable the private key with a password
 encrypted_private_key = []
 

--- a/examples-esp32c3/Cargo.toml
+++ b/examples-esp32c3/Cargo.toml
@@ -9,17 +9,17 @@ license = "MIT OR Apache-2.0"
 debug = true
 
 [dependencies]
-hal = { package = "esp32c3-hal", version = "0.8.0" }
+hal = { package = "esp32c3-hal", version = "0.9.0" }
 esp-backtrace = { version = "0.6.0", features = ["esp32c3", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.4.0", features = ["esp32c3","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"], optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "26474ce6eb759e5add1c137f3417845e0797df3a", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
+embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32c3", "embedded-svc", "wifi"], rev = "a01d075c64ddf777920344936f8bdaaddf7de288" }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32c3", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
 smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
-embedded-svc = { version = "0.23.1", default-features = false}
+embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"
 embedded-hal = "0.2"
 embedded-io = "0.4.0"
@@ -33,10 +33,7 @@ name              = "async"
 required-features = ["async"]
 
 [features]
-async = ["esp-wifi/esp32c3-async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
+async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
 # Use this feature to enable the private key with a password
 encrypted_private_key = []
 
-[patch.crates-io]
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32c3-hal", rev = "e5d1c603b0d4833632c2358ad3fad36964bf0ed5"}
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", package = "esp-hal-common", rev = "e5d1c603b0d4833632c2358ad3fad36964bf0ed5"}

--- a/examples-esp32c3/examples/async.rs
+++ b/examples-esp32c3/examples/async.rs
@@ -69,7 +69,7 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -144,7 +144,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -153,7 +153,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(Duration::from_secs(10)));
 
     let remote_endpoint = (Ipv4Address::new(142, 250, 185, 68), 443); // www.google.com
     println!("connecting...");

--- a/examples-esp32c3/examples/async.rs
+++ b/examples-esp32c3/examples/async.rs
@@ -14,8 +14,8 @@ use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::initialize;
 use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -50,7 +50,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER);
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.alarm0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
@@ -59,7 +60,7 @@ fn main() -> ! {
     .unwrap();
 
     let (wifi, _) = peripherals.RADIO.split();
-    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(wifi, WifiMode::Sta);
+    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta);
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/examples-esp32c3/examples/async_client.rs
+++ b/examples-esp32c3/examples/async_client.rs
@@ -69,7 +69,7 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -144,7 +144,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -153,7 +153,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(Duration::from_secs(10)));
 
     let remote_endpoint = (Ipv4Address::new(62, 210, 201, 125), 443); // certauth.cryptomix.com
     println!("connecting...");

--- a/examples-esp32c3/examples/async_client.rs
+++ b/examples-esp32c3/examples/async_client.rs
@@ -14,8 +14,8 @@ use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
 use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::initialize;
 use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -50,7 +50,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER);
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.alarm0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
@@ -59,7 +60,7 @@ fn main() -> ! {
     .unwrap();
 
     let (wifi, _) = peripherals.RADIO.split();
-    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(wifi, WifiMode::Sta);
+    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta);
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/examples-esp32c3/examples/sync.rs
+++ b/examples-esp32c3/examples/sync.rs
@@ -14,6 +14,7 @@ use esp_wifi::{
     current_millis, initialize,
     wifi::{utils::create_network_interface, WifiMode},
     wifi_interface::WifiStack,
+    EspWifiInitFor,
 };
 use hal::{
     clock::{ClockControl, CpuClock},
@@ -21,7 +22,7 @@ use hal::{
     prelude::*,
     Rng, Rtc,
 };
-use smoltcp::{iface::SocketStorage, wire::Ipv4Address};
+use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -40,20 +41,21 @@ fn main() -> ! {
     rtc.swd.disable();
     rtc.rwdt.disable();
 
-    let (wifi, _) = peripherals.RADIO.split();
-    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(wifi, WifiMode::Sta, &mut socket_set_entries);
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
-
     let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER);
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.alarm0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
         &clocks,
     )
     .unwrap();
+
+    let (wifi, _) = peripherals.RADIO.split();
+    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries);
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
@@ -102,7 +104,7 @@ fn main() -> ! {
     socket.work();
 
     socket
-        .open(Ipv4Address::new(142, 250, 185, 68), 443) // google.com
+        .open(IpAddress::v4(142, 250, 185, 68), 443) // google.com
         .unwrap();
 
     set_debug(0);

--- a/examples-esp32s3/Cargo.toml
+++ b/examples-esp32s3/Cargo.toml
@@ -7,19 +7,29 @@ license = "MIT OR Apache-2.0"
 
 [profile.release]
 debug = true
+lto = false
+
+[profile.release.package.esp-wifi]
+opt-level = 3
+
+[profile.dev]
+lto = false
+
+[profile.dev.package.esp-wifi]
+opt-level = 3
 
 [dependencies]
-hal = { package = "esp32s3-hal", version = "0.8.0" }
+hal = { package = "esp32s3-hal", version = "0.9.0" }
 esp-backtrace = { version = "0.6.0", features = ["esp32s3", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.4.0", features = ["esp32s3","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
-embassy-executor  = { package = "embassy-executor", git = "https://github.com/embassy-rs/embassy/", rev = "cd9a65b", features = ["nightly", "integrated-timers"], optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "26474ce6eb759e5add1c137f3417845e0797df3a", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
+embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32s3", "embedded-svc", "wifi"], rev = "a01d075c64ddf777920344936f8bdaaddf7de288" }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "esp32s3", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
 smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
-embedded-svc = { version = "0.23.1", default-features = false}
+embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"
 embedded-hal = "0.2"
 embedded-io = "0.4.0"
@@ -33,10 +43,7 @@ name              = "async"
 required-features = ["async"]
 
 [features]
-async = ["esp-wifi/esp32s3-async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
+async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
 # Use this feature to enable the private key with a password
 encrypted_private_key = []
 
-[patch.crates-io]
-esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32s3-hal", rev = "e5d1c603b0d4833632c2358ad3fad36964bf0ed5"}
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", package = "esp-hal-common", rev = "e5d1c603b0d4833632c2358ad3fad36964bf0ed5"}

--- a/examples-esp32s3/Cargo.toml
+++ b/examples-esp32s3/Cargo.toml
@@ -27,7 +27,7 @@ embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
 embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
 embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "esp32s3", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32s3", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
 smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"

--- a/examples-esp32s3/Cargo.toml
+++ b/examples-esp32s3/Cargo.toml
@@ -19,16 +19,16 @@ lto = false
 opt-level = 3
 
 [dependencies]
-hal = { package = "esp32s3-hal", version = "0.9.0" }
+hal = { package = "esp32s3-hal", version = "0.10.0" }
 esp-backtrace = { version = "0.6.0", features = ["esp32s3", "panic-handler", "print-uart", "exception-handler"] }
 esp-println       = { version = "0.4.0", features = ["esp32s3","log"] }
 
 embassy-time = { version = "0.1.0", features = ["nightly"], optional = true }
 embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers", "arch-xtensa"], optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32s3", "embedded-svc", "wifi"], rev = "f80df630a887b27fa63fb2043fd2a432d431ac2f" }
-smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = ["big-heap", "phy-enable-usb", "esp32s3", "embedded-svc", "wifi"], rev = "68dc11bbb2c0efa29c4acbbf134d6f142441065e" }
+smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 embedded-svc = { version = "0.25.0", default-features = false}
 log = "0.4.16"
 embedded-hal = "0.2"
@@ -43,7 +43,7 @@ name              = "async"
 required-features = ["async"]
 
 [features]
-async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async"]
+async = ["esp-wifi/async", "esp-wifi/embassy-net", "embassy-executor", "embassy-net", "embassy-time", "embedded-io/async", "hal/embassy-time-timg0"]
 # Use this feature to enable the private key with a password
 encrypted_private_key = []
 

--- a/examples-esp32s3/examples/async.rs
+++ b/examples-esp32s3/examples/async.rs
@@ -14,8 +14,8 @@ use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::initialize;
 use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -53,7 +53,8 @@ fn main() -> ! {
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.timer0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
@@ -62,7 +63,7 @@ fn main() -> ! {
     .unwrap();
 
     let (wifi, _) = peripherals.RADIO.split();
-    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(wifi, WifiMode::Sta);
+    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta);
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/examples-esp32s3/examples/async.rs
+++ b/examples-esp32s3/examples/async.rs
@@ -72,7 +72,7 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -147,7 +147,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -156,7 +156,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(Duration::from_secs(10)));
 
     let remote_endpoint = (Ipv4Address::new(142, 250, 186, 36), 443); // www.google.com
     println!("connecting...");

--- a/examples-esp32s3/examples/async_client.rs
+++ b/examples-esp32s3/examples/async_client.rs
@@ -72,7 +72,7 @@ fn main() -> ! {
     );
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -147,7 +147,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -156,7 +156,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(Duration::from_secs(10)));
 
     let remote_endpoint = (Ipv4Address::new(62, 210, 201, 125), 443); // certauth.cryptomix.com
     println!("connecting...");

--- a/examples-esp32s3/examples/async_client.rs
+++ b/examples-esp32s3/examples/async_client.rs
@@ -14,8 +14,8 @@ use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
 use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::initialize;
 use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -53,7 +53,8 @@ fn main() -> ! {
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    initialize(
+    let init = initialize(
+        EspWifiInitFor::Wifi,
         timer.timer0,
         Rng::new(peripherals.RNG),
         system.radio_clock_control,
@@ -62,7 +63,7 @@ fn main() -> ! {
     .unwrap();
 
     let (wifi, _) = peripherals.RADIO.split();
-    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(wifi, WifiMode::Sta);
+    let (wifi_interface, controller) = esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta);
 
     let timer_group0 = TimerGroup::new(
         peripherals.TIMG0,

--- a/examples-esp32s3/examples/sync_client.rs
+++ b/examples-esp32s3/examples/sync_client.rs
@@ -14,6 +14,7 @@ use esp_wifi::{
     current_millis,
     wifi::{utils::create_network_interface, WifiMode},
     wifi_interface::WifiStack,
+    EspWifiInitFor,
 };
 use hal::timer::TimerGroup;
 use hal::{
@@ -22,7 +23,7 @@ use hal::{
     prelude::*,
     Rng, Rtc,
 };
-use smoltcp::{iface::SocketStorage, wire::Ipv4Address};
+use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -40,19 +41,26 @@ fn main() -> ! {
     // Disable watchdog timers
     rtc.rwdt.disable();
 
-    let (wifi, _) = peripherals.RADIO.split();
-    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(wifi, WifiMode::Sta, &mut socket_set_entries);
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
-
     let rngp = Rng::new(peripherals.RNG);
     let timer = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,
     );
-    esp_wifi::initialize(timer.timer0, rngp, system.radio_clock_control, &clocks).unwrap();
+    let init = esp_wifi::initialize(
+        EspWifiInitFor::Wifi,
+        timer.timer0,
+        rngp,
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let (wifi, _) = peripherals.RADIO.split();
+    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries);
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
@@ -101,7 +109,7 @@ fn main() -> ! {
     socket.work();
 
     socket
-        .open(Ipv4Address::new(62, 210, 201, 125), 443) // certauth.cryptomix.com
+        .open(IpAddress::v4(62, 210, 201, 125), 443) // certauth.cryptomix.com
         .unwrap();
 
     set_debug(0);


### PR DESCRIPTION
Update `esp-wifi` and `esp-hal` to the latest version.

I've currently only done esp32s3, because it's the only chip that I have on hand. 

I'm getting multiple crashes, for many different reasons, like illegal instructions, or index out of bounds.. I'm also getting this kind of error on another project using this library, so it feels like it's specific to esp-wifi and / or esp-mbedtls. I can't figure this one out.

Tested on both `1.69.0` and `1.70.0`.