### PR TITLE
Fix crash when using debug level 3 or higher

### DIFF
--- a/esp-mbedtls/src/compat.rs
+++ b/esp-mbedtls/src/compat.rs
@@ -38,7 +38,7 @@ extern "C" fn vsnprintf(
                     res_str.append_char(c);
                 }
             } else {
-                if c.is_numeric() || c == '-' || c == 'l' || c == 'z' {
+                if c.is_numeric() || c == '-' || c == 'l' || c == 'z' || c == '#' {
                     if c == 'l' {
                         is_long = true;
                     }


### PR DESCRIPTION
Fixes a crash that was happening when using debug level 3 or higher due to an unexpected character that wasn't handled

Fixes #11 