### PR TITLE
Recommend using cfg.toml instead of big-heap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ embassy-net = { version = "0.2.1", features = [
 ], optional = true }
 
 esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = [
-    "big-heap",
     "phy-enable-usb",
     "embedded-svc",
     "wifi",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It comes with mbedtls precompiled to avoid the need for a complete C toolchain. 
 
 This should work together with `esp-wifi`. It currently won't work without. However it's not well tested yet besides the included examples.
 
-See the examples for how to use it. A key thing is to enable the feature `big-heap` in esp-wifi since more heap memory is needed to get this working.
+See the examples for how to use it. A key thing is to [set a bigger heap size](https://github.com/esp-rs/esp-wifi/blob/main/esp-wifi/docs/tuning.md) for esp-wifi since more heap memory is needed to get this working.
 
 In general this is heavy in terms of heap memory used and code size. If you can, you should prefer using something like `embedded-tls`.
 

--- a/cfg.toml
+++ b/cfg.toml
@@ -1,0 +1,3 @@
+[esp-wifi]
+heap_size = 112640 # use 110k by default
+# heap_size = 73728 # uncomment this to use 72k for esp32-s2/c2


### PR DESCRIPTION
Companion PR of https://github.com/esp-rs/esp-wifi/pull/367

We can start recommending cfg.toml even before we remove big-heap (so I didn't change the esp-wifi rev).

