### PR TITLE
revert: Changes Session back to own the socket

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,6 @@ rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Trom_functions.x",
-  "-C", "target-feature=-loop",
 ]
 
 [target.riscv32imc-unknown-none-elf]
@@ -18,22 +17,6 @@ rustflags = [
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",
-
-  # comment the cfgs below if you do _not_ wish to emulate atomics.
-  # enable the atomic codegen option for RISCV
-  "-C", "target-feature=+a",
-  # tell the core library have atomics even though it's not specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-  # enable cas
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [target.xtensa-esp32s2-none-elf]
@@ -44,22 +27,6 @@ rustflags = [
     
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Trom_functions.x",
-
-    # Enable the atomic codegen option for Xtensa
-    "-C", "target-feature=+s32c1i",
-
-  # tell the core library have atomics even though it's not specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-  # enable cas
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [target.xtensa-esp32s3-none-elf]
@@ -69,7 +36,6 @@ rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "link-arg=-nostartfiles",
   "-C", "link-arg=-Trom_functions.x",
-  "-C", "target-feature=-loop",
 ]
 
 [unstable]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,25 +19,24 @@ lto = false
 opt-level = 3
 
 [dependencies]
-esp32-hal = { version = "0.16.0", optional = true }
-esp32c3-hal = { version = "0.13.0", optional = true }
-esp32s2-hal = { version = "0.13.0", optional = true }
-esp32s3-hal = { version = "0.13.0", optional = true }
-esp-backtrace = { version = "0.9.0", features = [
+esp32-hal = { version = "0.18.0", optional = true }
+esp32c3-hal = { version = "0.15.0", optional = true }
+esp32s2-hal = { version = "0.15.0", optional = true }
+esp32s3-hal = { version = "0.15.0", optional = true }
+esp-backtrace = { version = "0.11.0", features = [
     "panic-handler",
-    "print-uart",
+    "println",
     "exception-handler",
 ] }
-esp-println = { version = "0.7.0", features = ["log"] }
+esp-println = { version = "0.9.0", features = ["log"] }
 
-embassy-time = { version = "0.1.3", features = ["nightly"], optional = true }
-embassy-executor = { version = "0.3.0", package = "embassy-executor", features = [
+embassy-time = { version = "0.3.0", optional = true }
+embassy-executor = { version = "0.5.0", package = "embassy-executor", features = [
     "nightly",
     "executor-thread",
     "integrated-timers",
 ], optional = true }
-embassy-net = { version = "0.2.1", features = [
-    "nightly",
+embassy-net = { version = "0.4.0", features = [
     "tcp",
     "udp",
     "dhcpv4",
@@ -47,9 +46,9 @@ embassy-net = { version = "0.2.1", features = [
 esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = [
     "phy-enable-usb",
     "embedded-svc",
-    "wifi",
-], rev = "516608916e71671e99c234511df93801fde2d3a3" }
-smoltcp = { version = "0.10.0", default-features = false, features = [
+    "wifi-default",
+], rev = "e6c58b67569c290f27e38846fcf628d893e562c1" }
+smoltcp = { version = "0.11.0", default-features = false, features = [
     "proto-igmp",
     "proto-ipv4",
     "socket-tcp",
@@ -60,12 +59,11 @@ smoltcp = { version = "0.10.0", default-features = false, features = [
     "socket-raw",
     "socket-dhcpv4",
 ] }
-embedded-svc = { version = "0.26.2", default-features = false }
 log = "0.4.16"
 embedded-hal = "0.2"
 embedded-io = "0.6.1"
 embedded-io-async = { version = "0.6.0", optional = true }
-heapless = "0.7.16"
+heapless = "0.8.0"
 critical-section = "1.0.1"
 static_cell = { version = "=1.2", features = ["nightly"] }
 
@@ -101,7 +99,6 @@ esp32c3 = [
     "esp32c3-hal/embassy-time-timg0",
     "esp-backtrace/esp32c3",
     "esp-println/esp32c3",
-    "embassy-executor?/arch-riscv32",
     "esp-wifi/esp32c3",
     "esp-mbedtls/esp32c3",
 ]
@@ -135,6 +132,7 @@ async = [
     "esp32-hal?/async",
     "esp32s2-hal?/async",
     "esp32s3-hal?/async",
+    "esp32c3-hal?/embassy-executor-thread",
     "esp32-hal?/embassy-executor-thread",
     "esp32s2-hal?/embassy-executor-thread",
     "esp32s3-hal?/embassy-executor-thread",

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -2,16 +2,17 @@
 name = "esp-mbedtls"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.74"
 
 [dependencies]
 esp-mbedtls-sys = { path = "../esp-mbedtls-sys" }
 log = "0.4.17"
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.0", optional = true }
-esp32-hal = { version = "0.16.0", optional = true }
-esp32c3-hal = { version = "0.13.0", optional = true }
-esp32s2-hal = { version = "0.13.0", optional = true }
-esp32s3-hal = { version = "0.13.0", optional = true }
+esp32-hal = { version = "0.18.0", optional = true }
+esp32c3-hal = { version = "0.15.0", optional = true }
+esp32s2-hal = { version = "0.15.0", optional = true }
+esp32s3-hal = { version = "0.15.0", optional = true }
 
 [features]
 async = ["dep:embedded-io-async"]

--- a/esp-mbedtls/src/compat.rs
+++ b/esp-mbedtls/src/compat.rs
@@ -2,11 +2,6 @@ use core::ffi::VaListImpl;
 use core::fmt::Write;
 
 #[no_mangle]
-extern "C" fn putchar() {
-    todo!()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn snprintf(dst: *mut u8, n: u32, format: *const u8, args: ...) -> i32 {
     vsnprintf(dst, n, format, args)
 }

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(c_variadic)]
-#![feature(async_fn_in_trait)]
-#![feature(impl_trait_projections)]
 #![allow(incomplete_features)]
 
 use embedded_io::ErrorType;

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -22,13 +22,15 @@ use embassy_net::{Config, Ipv4Address, Stack, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_mbedtls::X509;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiStaDevice, WifiState};
+use esp_wifi::wifi::{
+    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+    WifiState,
+};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -64,7 +66,7 @@ async fn main(spawner: Spawner) -> ! {
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -179,8 +181,8 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/examples/async_client_mTLS.rs
+++ b/examples/async_client_mTLS.rs
@@ -22,13 +22,15 @@ use embassy_net::tcp::TcpSocket;
 use embassy_net::{Config, Ipv4Address, Stack, StackResources};
 
 use embassy_time::{Duration, Timer};
-use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_mbedtls::{asynch::Session, set_debug, Mode, TlsVersion};
 use esp_mbedtls::{Certificates, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiStaDevice, WifiState};
+use esp_wifi::wifi::{
+    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+    WifiState,
+};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -64,7 +66,7 @@ async fn main(spawner: Spawner) -> ! {
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -185,8 +187,8 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -25,13 +25,15 @@ use embassy_net::{Config, Stack, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_mbedtls::{TlsError, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiStaDevice, WifiState};
+use esp_wifi::wifi::{
+    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+    WifiState,
+};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -68,7 +70,7 @@ async fn main(spawner: Spawner) -> ! {
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -229,8 +231,8 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/examples/async_server_mTLS.rs
+++ b/examples/async_server_mTLS.rs
@@ -42,13 +42,15 @@ use embassy_net::{Config, Stack, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
-use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_mbedtls::{TlsError, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiStaDevice, WifiState};
+use esp_wifi::wifi::{
+    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+    WifiState,
+};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -85,7 +87,7 @@ async fn main(spawner: Spawner) -> ! {
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0.timer0);
+    embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -251,8 +253,8 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/examples/sync_client.rs
+++ b/examples/sync_client.rs
@@ -17,17 +17,13 @@ pub use esp32s2_hal as hal;
 pub use esp32s3_hal as hal;
 
 use embedded_io::*;
-use embedded_svc::{
-    ipv4::Interface,
-    wifi::{ClientConfiguration, Configuration, Wifi},
-};
 use esp_backtrace as _;
 use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     current_millis, initialize,
-    wifi::{utils::create_network_interface, WifiStaDevice},
+    wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
@@ -66,8 +62,8 @@ fn main() -> ! {
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     controller.set_configuration(&client_config).unwrap();

--- a/examples/sync_client_mTLS.rs
+++ b/examples/sync_client_mTLS.rs
@@ -17,17 +17,13 @@ pub use esp32s2_hal as hal;
 pub use esp32s3_hal as hal;
 
 use embedded_io::*;
-use embedded_svc::{
-    ipv4::Interface,
-    wifi::{ClientConfiguration, Configuration, Wifi},
-};
 use esp_backtrace as _;
 use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     current_millis, initialize,
-    wifi::{utils::create_network_interface, WifiStaDevice},
+    wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
@@ -66,8 +62,8 @@ fn main() -> ! {
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     controller.set_configuration(&client_config).unwrap();

--- a/examples/sync_server.rs
+++ b/examples/sync_server.rs
@@ -20,17 +20,13 @@ pub use esp32s2_hal as hal;
 pub use esp32s3_hal as hal;
 
 use embedded_io::*;
-use embedded_svc::{
-    ipv4::Interface,
-    wifi::{ClientConfiguration, Configuration, Wifi},
-};
 use esp_backtrace as _;
 use esp_mbedtls::{set_debug, Mode, TlsError, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     current_millis, initialize,
-    wifi::{utils::create_network_interface, WifiStaDevice},
+    wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
@@ -69,8 +65,8 @@ fn main() -> ! {
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     controller.set_configuration(&client_config).unwrap();

--- a/examples/sync_server_mTLS.rs
+++ b/examples/sync_server_mTLS.rs
@@ -37,17 +37,13 @@ pub use esp32s2_hal as hal;
 pub use esp32s3_hal as hal;
 
 use embedded_io::*;
-use embedded_svc::{
-    ipv4::Interface,
-    wifi::{ClientConfiguration, Configuration, Wifi},
-};
 use esp_backtrace as _;
 use esp_mbedtls::{set_debug, Mode, TlsError, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     current_millis, initialize,
-    wifi::{utils::create_network_interface, WifiStaDevice},
+    wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
@@ -86,8 +82,8 @@ fn main() -> ! {
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     controller.set_configuration(&client_config).unwrap();


### PR DESCRIPTION
This was done as a fix for the server, but it seems that letting T and simply passing &mut T fixes the original issue this PR was intended to fix.

Other libraries like `embedded_tls` take ownership of the socket. This allows to move the session around without having to keep a reference to the socket alive.

I've ran the justfile and everything compiles. This unblocks my fork of reqwless that attempts to use `esp-mbedtls` as a TLS wrapper (_coming soon_).

Ref: c094cfc