### PR TITLE
Re-export Rsa since it is a parameter of Session::new()

### DIFF
--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -16,7 +16,7 @@ pub use esp32s2_hal as hal;
 #[cfg(feature = "esp32s3")]
 pub use esp32s3_hal as hal;
 
-use crate::hal::rsa::Rsa;
+pub use crate::hal::rsa::Rsa;
 
 mod compat;
 


### PR DESCRIPTION
This is a quality of life improvement, as it allows a library to wrap esp-mbedtls without having to re-import the hal for the Rsa struct.