### PR TITLE
Update to esp-hal 0.18.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -47,12 +47,12 @@ xtask = "run --manifest-path ./xtask/Cargo.toml --"
 # Alias' for quickly building for different chips or running examples
 # By default we enable
 #   - `default` HAL features to set up basic chip specific settings
-esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
-esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
-esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
-esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
+esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default"
+esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default"
+esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default"
+esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default"
 
-besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
-besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
-besp32s3 = "build --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
-besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default,esp-hal/embassy-time-timg0,esp-hal/embassy-executor-thread"
+besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default"
+besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default"
+besp32s3 = "build --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default"
+besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: nightly
+          toolchain: nightly-2024-06-12
           components: rust-src,rustfmt
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,19 @@ lto = false
 opt-level = 3
 
 [dependencies]
-esp-hal = { version = "0.16.1" }
-esp-backtrace = { version = "0.11.0", features = [
+esp-hal = { version = "0.18.0" }
+esp-backtrace = { version = "0.12.1", features = [
     "panic-handler",
     "println",
     "exception-handler",
 ] }
 esp-println = { version = "0.9.0", features = ["log"] }
+esp-hal-embassy = { version = "0.1.0", optional = true }
 
 embassy-time = { version = "0.3.0", optional = true }
 embassy-executor = { version = "0.5.0", package = "embassy-executor", features = [
     "nightly",
-    "integrated-timers"
+    "integrated-timers",
 ], optional = true }
 embassy-net = { version = "0.4.0", features = [
     "tcp",
@@ -40,11 +41,12 @@ embassy-net = { version = "0.4.0", features = [
     "medium-ethernet",
 ], optional = true }
 
-esp-wifi = { git = "https://github.com/esp-rs/esp-wifi.git", features = [
+
+esp-wifi = { version = "0.6.0", features = [
     "phy-enable-usb",
     "embedded-svc",
     "wifi-default",
-], version = "0.4.0" }
+] }
 smoltcp = { version = "0.11.0", default-features = false, features = [
     "proto-igmp",
     "proto-ipv4",
@@ -123,6 +125,6 @@ async = [
     "embassy-time",
     "dep:embedded-io-async",
     "esp-mbedtls/async",
-    "esp-hal/embassy",
+    "esp-hal-embassy/time-timg0",
     "esp-hal/async",
 ]

--- a/cfg.toml
+++ b/cfg.toml
@@ -1,3 +1,3 @@
 [esp-wifi]
-heap_size = 112640 # use 110k by default
+heap_size = 95000 # use 110k by default
 # heap_size = 73728 # uncomment this to use 72k for esp32-s2/c2

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4.17"
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.0", optional = true }
 crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"] }
-esp-hal = { version = "0.16.1" }
+esp-hal = { version = "0.18.0" }
 cfg-if = "1.0.0"
 
 [features]

--- a/esp-mbedtls/src/bignum.rs
+++ b/esp-mbedtls/src/bignum.rs
@@ -189,7 +189,10 @@ pub unsafe extern "C" fn mbedtls_mpi_exp_mod(
                         copy_bytes(Y.private_p, exponent.as_mut_ptr(), y_words);
                         copy_bytes(M.private_p, modulus.as_mut_ptr(), m_words);
                         copy_bytes(rinv.private_p, r.as_mut_ptr(), mpi_words(rinv));
-                        let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op256>::new(
+                        let mut mod_exp = RsaModularExponentiation::<
+                            operand_sizes::Op256,
+                            esp_hal::Blocking,
+                        >::new(
                             rsa,
                             &exponent,         // exponent (Y) Y_MEM
                             &modulus,          // modulus (M)  M_MEM
@@ -214,7 +217,10 @@ pub unsafe extern "C" fn mbedtls_mpi_exp_mod(
                         copy_bytes(Y.private_p, exponent.as_mut_ptr(), y_words);
                         copy_bytes(M.private_p, modulus.as_mut_ptr(), m_words);
                         copy_bytes(rinv.private_p, r.as_mut_ptr(), mpi_words(rinv));
-                        let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op384>::new(
+                        let mut mod_exp = RsaModularExponentiation::<
+                            operand_sizes::Op384,
+                            esp_hal::Blocking,
+                        >::new(
                             rsa,
                             &exponent,         // exponent (Y) Y_MEM
                             &modulus,          // modulus (M)  M_MEM
@@ -239,7 +245,10 @@ pub unsafe extern "C" fn mbedtls_mpi_exp_mod(
                         copy_bytes(Y.private_p, exponent.as_mut_ptr(), y_words);
                         copy_bytes(M.private_p, modulus.as_mut_ptr(), m_words);
                         copy_bytes(rinv.private_p, r.as_mut_ptr(), mpi_words(rinv));
-                        let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op512>::new(
+                        let mut mod_exp = RsaModularExponentiation::<
+                            operand_sizes::Op512,
+                            esp_hal::Blocking,
+                        >::new(
                             rsa,
                             &exponent,         // exponent (Y) Y_MEM
                             &modulus,          // modulus (M)  M_MEM
@@ -264,7 +273,10 @@ pub unsafe extern "C" fn mbedtls_mpi_exp_mod(
                         copy_bytes(Y.private_p, exponent.as_mut_ptr(), y_words);
                         copy_bytes(M.private_p, modulus.as_mut_ptr(), m_words);
                         copy_bytes(rinv.private_p, r.as_mut_ptr(), mpi_words(rinv));
-                        let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op1024>::new(
+                        let mut mod_exp = RsaModularExponentiation::<
+                            operand_sizes::Op1024,
+                            esp_hal::Blocking,
+                        >::new(
                             rsa,
                             &exponent,         // exponent (Y) Y_MEM
                             &modulus,          // modulus (M)  M_MEM
@@ -289,7 +301,10 @@ pub unsafe extern "C" fn mbedtls_mpi_exp_mod(
                         copy_bytes(Y.private_p, exponent.as_mut_ptr(), y_words);
                         copy_bytes(M.private_p, modulus.as_mut_ptr(), m_words);
                         copy_bytes(rinv.private_p, r.as_mut_ptr(), mpi_words(rinv));
-                        let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op2048>::new(
+                        let mut mod_exp = RsaModularExponentiation::<
+                            operand_sizes::Op2048,
+                            esp_hal::Blocking,
+                        >::new(
                             rsa,
                             &exponent,         // exponent (Y) Y_MEM
                             &modulus,          // modulus (M)  M_MEM
@@ -315,7 +330,10 @@ pub unsafe extern "C" fn mbedtls_mpi_exp_mod(
                         copy_bytes(Y.private_p, exponent.as_mut_ptr(), y_words);
                         copy_bytes(M.private_p, modulus.as_mut_ptr(), m_words);
                         copy_bytes(rinv.private_p, r.as_mut_ptr(), mpi_words(rinv));
-                        let mut mod_exp = RsaModularExponentiation::<operand_sizes::Op4096>::new(
+                        let mut mod_exp = RsaModularExponentiation::<
+                            operand_sizes::Op4096,
+                            esp_hal::Blocking,
+                        >::new(
                             rsa,
                             &exponent,         // exponent (Y) Y_MEM
                             &modulus,          // modulus (M)  M_MEM

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -5,9 +5,7 @@
 use embedded_io::ErrorType;
 #[doc(hidden)]
 pub use esp_hal as hal;
-use hal::{peripheral::Peripheral, peripherals::RSA};
-
-pub use crate::hal::rsa::Rsa;
+use hal::{peripheral::Peripheral, peripherals::RSA, rsa::Rsa};
 
 mod compat;
 

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -5,6 +5,7 @@
 use embedded_io::ErrorType;
 #[doc(hidden)]
 pub use esp_hal as hal;
+use hal::{peripheral::Peripheral, peripherals::RSA};
 
 pub use crate::hal::rsa::Rsa;
 
@@ -30,7 +31,7 @@ pub use esp_mbedtls_sys::bindings::{
 use esp_mbedtls_sys::c_types::*;
 
 /// Hold the RSA peripheral for cryptographic operations.
-static mut RSA_REF: Option<&mut Rsa> = None;
+static mut RSA_REF: Option<Rsa<esp_hal::Blocking>> = None;
 
 // these will come from esp-wifi (i.e. this can only be used together with esp-wifi)
 extern "C" {
@@ -414,11 +415,11 @@ impl<T> Session<T> {
         mode: Mode,
         min_version: TlsVersion,
         certificates: Certificates,
-        rsa: Option<&mut Rsa>,
+        rsa: Option<impl Peripheral<P = RSA>>,
     ) -> Result<Self, TlsError> {
         let (ssl_context, ssl_config, crt, client_crt, private_key) =
             certificates.init_ssl(servername, mode, min_version)?;
-        unsafe { RSA_REF = core::mem::transmute(rsa) }
+        unsafe { RSA_REF = core::mem::transmute(rsa.map(|inner| Rsa::new(inner, None))) }
         return Ok(Self {
             stream,
             ssl_context,
@@ -640,11 +641,11 @@ pub mod asynch {
             mode: Mode,
             min_version: TlsVersion,
             certificates: Certificates,
-            rsa: Option<&mut Rsa>,
+            rsa: Option<impl Peripheral<P = RSA>>,
         ) -> Result<Self, TlsError> {
             let (ssl_context, ssl_config, crt, client_crt, private_key) =
                 certificates.init_ssl(servername, mode, min_version)?;
-            unsafe { RSA_REF = core::mem::transmute(rsa) }
+            unsafe { RSA_REF = core::mem::transmute(rsa.map(|inner| Rsa::new(inner, None))) }
             return Ok(Self {
                 stream,
                 ssl_context,

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -22,9 +22,10 @@ use esp_wifi::wifi::{
     WifiState,
 };
 use esp_wifi::{initialize, EspWifiInitFor};
-use hal::clock::ClockControl;
-use hal::Rng;
-use hal::{embassy, peripherals::Peripherals, prelude::*, rsa::Rsa, timer::TimerGroup};
+use hal::{
+    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
+};
 use static_cell::make_static;
 
 const SSID: &str = env!("SSID");
@@ -35,18 +36,18 @@ async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
     let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
+    let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(feature = "esp32c3")]
-    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "xtensa")]
+    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
     let init = initialize(
         EspWifiInitFor::Wifi,
         timer,
         Rng::new(peripherals.RNG),
-        system.radio_clock_control,
+        peripherals.RADIO_CLK,
         &clocks,
     )
     .unwrap();
@@ -55,8 +56,8 @@ async fn main(spawner: Spawner) -> ! {
     let (wifi_interface, controller) =
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0);
+    let timer_group0 = TimerGroup::new_async(peripherals.TIMG0, &clocks);
+    esp_hal_embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -106,8 +107,6 @@ async fn main(spawner: Spawner) -> ! {
 
     set_debug(0);
 
-    let mut rsa = Rsa::new(peripherals.RSA);
-
     let tls: Session<_, 4096> = Session::new(
         &mut socket,
         "www.google.com",
@@ -120,7 +119,7 @@ async fn main(spawner: Spawner) -> ! {
             .ok(),
             ..Default::default()
         },
-        Some(&mut rsa),
+        Some(peripherals.RSA),
     )
     .unwrap();
 

--- a/examples/async_client_mTLS.rs
+++ b/examples/async_client_mTLS.rs
@@ -22,9 +22,10 @@ use esp_wifi::wifi::{
     WifiState,
 };
 use esp_wifi::{initialize, EspWifiInitFor};
-use hal::clock::ClockControl;
-use hal::Rng;
-use hal::{embassy, peripherals::Peripherals, prelude::*, rsa::Rsa, timer::TimerGroup};
+use hal::{
+    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
+};
 use static_cell::make_static;
 
 const SSID: &str = env!("SSID");
@@ -35,18 +36,18 @@ async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
     let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
+    let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(feature = "esp32c3")]
-    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "xtensa")]
+    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
     let init = initialize(
         EspWifiInitFor::Wifi,
         timer,
         Rng::new(peripherals.RNG),
-        system.radio_clock_control,
+        peripherals.RADIO_CLK,
         &clocks,
     )
     .unwrap();
@@ -55,8 +56,8 @@ async fn main(spawner: Spawner) -> ! {
     let (wifi_interface, controller) =
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0);
+    let timer_group0 = TimerGroup::new_async(peripherals.TIMG0, &clocks);
+    esp_hal_embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -106,8 +107,6 @@ async fn main(spawner: Spawner) -> ! {
 
     set_debug(0);
 
-    let mut rsa = Rsa::new(peripherals.RSA);
-
     let certificates = Certificates {
         ca_chain: X509::pem(
             concat!(include_str!("./certs/certauth.cryptomix.com.pem"), "\0").as_bytes(),
@@ -126,7 +125,7 @@ async fn main(spawner: Spawner) -> ! {
         Mode::Client,
         TlsVersion::Tls1_3,
         certificates,
-        Some(&mut rsa),
+        Some(peripherals.RSA),
     )
     .unwrap();
 

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -25,9 +25,10 @@ use esp_wifi::wifi::{
     WifiState,
 };
 use esp_wifi::{initialize, EspWifiInitFor};
-use hal::clock::ClockControl;
-use hal::Rng;
-use hal::{embassy, peripherals::Peripherals, prelude::*, rsa::Rsa, timer::TimerGroup};
+use hal::{
+    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
+};
 use static_cell::make_static;
 
 const SSID: &str = env!("SSID");
@@ -37,19 +38,19 @@ const PASSWORD: &str = env!("PASSWORD");
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
+    let mut peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(feature = "esp32c3")]
-    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "xtensa")]
+    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
     let init = initialize(
         EspWifiInitFor::Wifi,
         timer,
         Rng::new(peripherals.RNG),
-        system.radio_clock_control,
+        peripherals.RADIO_CLK,
         &clocks,
     )
     .unwrap();
@@ -58,8 +59,8 @@ async fn main(spawner: Spawner) -> ! {
     let (wifi_interface, controller) =
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timer_group0);
+    let timer_group0 = TimerGroup::new_async(peripherals.TIMG0, &clocks);
+    esp_hal_embassy::init(&clocks, timer_group0);
 
     let config = Config::dhcpv4(Default::default());
 
@@ -100,7 +101,6 @@ async fn main(spawner: Spawner) -> ! {
     }
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    let mut rsa = Rsa::new(peripherals.RSA);
     socket.set_timeout(Some(Duration::from_secs(10)));
     loop {
         println!("Waiting for connection...");
@@ -140,7 +140,7 @@ async fn main(spawner: Spawner) -> ! {
                 .ok(),
                 ..Default::default()
             },
-            Some(&mut rsa),
+            Some(&mut peripherals.RSA),
         )
         .unwrap();
 

--- a/examples/sync_client.rs
+++ b/examples/sync_client.rs
@@ -17,7 +17,9 @@ use esp_wifi::{
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
-use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rsa::Rsa, Rng};
+use hal::{
+    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
+};
 use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
 const SSID: &str = env!("SSID");
@@ -28,18 +30,18 @@ fn main() -> ! {
     init_logger(log::LevelFilter::Info);
 
     let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
+    let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(feature = "esp32c3")]
-    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "xtensa")]
+    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
     let init = initialize(
         EspWifiInitFor::Wifi,
         timer,
         Rng::new(peripherals.RNG),
-        system.radio_clock_control,
+        peripherals.RADIO_CLK,
         &clocks,
     )
     .unwrap();
@@ -102,8 +104,6 @@ fn main() -> ! {
 
     set_debug(0);
 
-    let mut rsa = Rsa::new(peripherals.RSA);
-
     let tls = Session::new(
         &mut socket,
         "www.google.com",
@@ -116,7 +116,7 @@ fn main() -> ! {
             .ok(),
             ..Default::default()
         },
-        Some(&mut rsa),
+        Some(peripherals.RSA),
     )
     .unwrap();
 

--- a/examples/sync_server_mTLS.rs
+++ b/examples/sync_server_mTLS.rs
@@ -37,7 +37,9 @@ use esp_wifi::{
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
-use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, rsa::Rsa, Rng};
+use hal::{
+    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
+};
 use smoltcp::iface::SocketStorage;
 
 const SSID: &str = env!("SSID");
@@ -47,19 +49,19 @@ const PASSWORD: &str = env!("PASSWORD");
 fn main() -> ! {
     init_logger(log::LevelFilter::Info);
 
-    let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
+    let mut peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(feature = "esp32c3")]
-    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
-    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "xtensa")]
+    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
     let init = initialize(
         EspWifiInitFor::Wifi,
         timer,
         Rng::new(peripherals.RNG),
-        system.radio_clock_control,
+        peripherals.RADIO_CLK,
         &clocks,
     )
     .unwrap();
@@ -120,8 +122,6 @@ fn main() -> ! {
     socket.listen(443).unwrap();
     set_debug(0);
 
-    let mut rsa = Rsa::new(peripherals.RSA);
-
     loop {
         socket.work();
 
@@ -158,7 +158,7 @@ fn main() -> ! {
                     .ok(),
                     ..Default::default()
                 },
-                Some(&mut rsa),
+                Some(&mut peripherals.RSA),
             )
             .unwrap();
             match tls.connect() {

--- a/justfile
+++ b/justfile
@@ -1,17 +1,17 @@
 export SSID := "Dummy"
 export PASSWORD := "Dummy"
 
-all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly")
-    cd esp-mbedtls && cargo +nightly fmt --all -- --check
+all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-2024-06-12")
+    cd esp-mbedtls && cargo +nightly-2024-06-12 fmt --all -- --check
     
 [private]
 check arch toolchain:
-    cargo +{{ toolchain }} b{{ arch }} --example sync_client
-    cargo +{{ toolchain }} b{{ arch }} --example sync_client_mTLS
-    cargo +{{ toolchain }} b{{ arch }} --example async_client --features="async"
-    cargo +{{ toolchain }} b{{ arch }} --example async_client_mTLS --features="async"
-    cargo +{{ toolchain }} b{{ arch }} --example sync_server
-    cargo +{{ toolchain }} b{{ arch }} --example sync_server_mTLS
-    cargo +{{ toolchain }} b{{ arch }} --example async_server --features="async"
-    cargo +{{ toolchain }} b{{ arch }} --example async_server_mTLS --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --release --example sync_client
+    cargo +{{ toolchain }} b{{ arch }} --release --example sync_client_mTLS
+    cargo +{{ toolchain }} b{{ arch }} --release --example async_client --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --release --example async_client_mTLS --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --release --example sync_server
+    cargo +{{ toolchain }} b{{ arch }} --release --example sync_server_mTLS
+    cargo +{{ toolchain }} b{{ arch }} --release --example async_server --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --release --example async_server_mTLS --features="async"
     cargo +{{ toolchain }} fmt --all -- --check


### PR DESCRIPTION
- I've updated `esp-hal` to the latest current release. 
- I've locked the nightly version to `nightly-2024-06-12` until the fix in https://github.com/embassy-rs/embassy/issues/3078 gets released
- I've reduced `heap_size` in config to be able to build without overflowing segments.

:warning: Breaking Change :warning: 
- The `rsa` field of `Session::new()` now take the peripheral directly, instead of an instance of the driver, so that we can instantiate the driver ourselves, in blocking mode. This now also allow creating a session in a trait impl that immutably borrow `&self` without triggering the borrow checker, by declaring a field with `RefCell<Option<esp_hal::peripherals::RSA>>`, and calling `Session::new()` with the following for the rsa field:
```rust
if let Ok(ref mut rsa) = self.rsa.try_borrow_mut() {
    rsa.as_mut()
} else {
    None
},
```