### PR TITLE
Use a builder pattern for enabling hardware accelerated RSA

### DIFF
--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -119,9 +119,9 @@ async fn main(spawner: Spawner) -> ! {
             .ok(),
             ..Default::default()
         },
-        Some(peripherals.RSA),
     )
-    .unwrap();
+    .unwrap()
+    .with_hardware_rsa(peripherals.RSA);
 
     println!("Start tls connect");
     let mut tls = tls.connect().await.unwrap();

--- a/examples/async_client_mTLS.rs
+++ b/examples/async_client_mTLS.rs
@@ -125,9 +125,9 @@ async fn main(spawner: Spawner) -> ! {
         Mode::Client,
         TlsVersion::Tls1_3,
         certificates,
-        Some(peripherals.RSA),
     )
-    .unwrap();
+    .unwrap()
+    .with_hardware_rsa(peripherals.RSA);
 
     println!("Start tls connect");
     let mut tls = tls.connect().await.unwrap();

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -140,9 +140,9 @@ async fn main(spawner: Spawner) -> ! {
                 .ok(),
                 ..Default::default()
             },
-            Some(&mut peripherals.RSA),
         )
-        .unwrap();
+        .unwrap()
+        .with_hardware_rsa(&mut peripherals.RSA);
 
         println!("Start tls connect");
         match tls.connect().await {

--- a/examples/async_server_mTLS.rs
+++ b/examples/async_server_mTLS.rs
@@ -159,9 +159,9 @@ async fn main(spawner: Spawner) -> ! {
                 .ok(),
                 ..Default::default()
             },
-            Some(&mut peripherals.RSA),
         )
-        .unwrap();
+        .unwrap()
+        .with_hardware_rsa(&mut peripherals.RSA);
 
         println!("Start tls connect");
         match tls.connect().await {

--- a/examples/sync_client.rs
+++ b/examples/sync_client.rs
@@ -116,9 +116,9 @@ fn main() -> ! {
             .ok(),
             ..Default::default()
         },
-        Some(peripherals.RSA),
     )
-    .unwrap();
+    .unwrap()
+    .with_hardware_rsa(peripherals.RSA);
 
     println!("Start tls connect");
     let mut tls = tls.connect().unwrap();

--- a/examples/sync_client_mTLS.rs
+++ b/examples/sync_client_mTLS.rs
@@ -122,9 +122,9 @@ fn main() -> ! {
         Mode::Client,
         TlsVersion::Tls1_3,
         certificates,
-        Some(peripherals.RSA),
     )
-    .unwrap();
+    .unwrap()
+    .with_hardware_rsa(peripherals.RSA);
 
     println!("Start tls connect");
     let mut tls = tls.connect().unwrap();

--- a/examples/sync_server.rs
+++ b/examples/sync_server.rs
@@ -137,9 +137,10 @@ fn main() -> ! {
                     .ok(),
                     ..Default::default()
                 },
-                Some(&mut peripherals.RSA),
             )
-            .unwrap();
+            .unwrap()
+            .with_hardware_rsa(&mut peripherals.RSA);
+
             match tls.connect() {
                 Ok(mut connected_session) => {
                     loop {

--- a/examples/sync_server_mTLS.rs
+++ b/examples/sync_server_mTLS.rs
@@ -158,9 +158,10 @@ fn main() -> ! {
                     .ok(),
                     ..Default::default()
                 },
-                Some(&mut peripherals.RSA),
             )
-            .unwrap();
+            .unwrap()
+            .with_hardware_rsa(&mut peripherals.RSA);
+
             match tls.connect() {
                 Ok(mut connected_session) => {
                     loop {


### PR DESCRIPTION
Built on top of #30.

This PR refactors the way we pass the RSA peripheral to a Session, using the builder pattern.
This also adds documentation detailing the usage of hardware accelerated RSA.

Whereas the older implementation is on a per session basis, it comes with the issue that only a single session can use the peripheral at the same time, even if we hold RSA statically. It would also be overwritten for every session, if one session is initialized with `None`.

This implementation is closer to the actual usage we do with the peripheral, where it is passed through the FFI with a static, hence it will be used for every session. The RSA is safely dropped of usage when the session using the peripheral is dropped.

It also improves simplicity, because with the change in #30, using `None` for `RSA` would require specifying the type with `None::<esp_hal::peripherals::RSA>`.