### PR TITLE
Implement `edge_nal::TcpAccept` trait from `edge-net`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ static_cell = { version = "=1.2", features = ["nightly"] }
 
 esp-mbedtls = { path = "./esp-mbedtls" }
 
+edge-http = { package = "edge-http", git = "https://github.com/ivmarkov/edge-net/", optional = true }
+edge-nal-embassy = { package = "edge-nal-embassy", git = "https://github.com/ivmarkov/edge-net/", optional = true }
+
 [[example]]
 name = "crypto_self_test"
 required-features = ["esp-wifi/wifi-logs"]
@@ -86,6 +89,10 @@ required-features = ["async"]
 [[example]]
 name = "async_server_mTLS"
 required-features = ["async"]
+
+[[example]]
+name = "edge_server"
+required-features = ["async", "esp-hal-embassy", "edge-nal-embassy", "edge-http", "esp-mbedtls/edge-nal"]
 
 [features]
 esp32 = [

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -12,6 +12,9 @@ embedded-io-async = { version = "0.6.0", optional = true }
 crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"] }
 esp-hal = { version = "0.19.0" }
 cfg-if = "1.0.0"
+edge-nal = { package = "edge-nal", git = "https://github.com/ivmarkov/edge-net/", optional = true }
+edge-nal-embassy = { package = "edge-nal-embassy", git = "https://github.com/ivmarkov/edge-net/", optional = true }
+embassy-net = { version = "0.4", features = [ "tcp", "medium-ethernet"], optional = true }
 
 [features]
 async = ["dep:embedded-io-async"]
@@ -19,3 +22,6 @@ esp32 = ["esp-hal/esp32", "esp-mbedtls-sys/esp32"]
 esp32c3 = ["esp-hal/esp32c3", "esp-mbedtls-sys/esp32c3"]
 esp32s2 = ["esp-hal/esp32s2", "esp-mbedtls-sys/esp32s2"]
 esp32s3 = ["esp-hal/esp32s3", "esp-mbedtls-sys/esp32s3"]
+
+# Implement the traits defined in the latest HEAD of `edge-nal`
+edge-nal = ["dep:edge-nal", "dep:edge-nal-embassy", "dep:embassy-net"]

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -96,6 +96,9 @@ pub enum TlsError {
     X509MissingNullTerminator,
     /// The client has given no certificates for the request
     NoClientCertificate,
+    /// Errors from the edge-nal-embassy crate
+    #[cfg(feature = "edge-nal")]
+    TcpError(edge_nal_embassy::TcpError),
 }
 
 impl embedded_io::Error for TlsError {
@@ -1095,6 +1098,128 @@ pub mod asynch {
             }
 
             self.read_idx == self.write_idx
+        }
+    }
+
+    /// Implements edge-nal traits
+    #[cfg(feature = "edge-nal")]
+    pub use edge_nal_compat::*;
+
+    #[cfg(feature = "edge-nal")]
+    mod edge_nal_compat {
+
+        use super::{AsyncConnectedSession, Session};
+        use crate::{Certificates, Mode, Peripheral, Rsa, TlsError, TlsVersion, RSA, RSA_REF};
+        use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+        use edge_nal::TcpBind;
+        use edge_nal_embassy::{Tcp, TcpAccept, TcpSocket};
+
+        pub struct TlsAcceptor<
+            'd,
+            D: embassy_net::driver::Driver,
+            const N: usize,
+            const TX_SZ: usize,
+            const RX_SZ: usize,
+        > {
+            acceptor: TcpAccept<'d, D, N, TX_SZ, RX_SZ>,
+            version: TlsVersion,
+            certificates: Certificates<'d>,
+            owns_rsa: bool,
+        }
+
+        impl<'d, D, const N: usize, const TX_SZ: usize, const RX_SZ: usize> Drop
+            for TlsAcceptor<'d, D, N, TX_SZ, RX_SZ>
+        where
+            D: embassy_net::driver::Driver,
+        {
+            fn drop(&mut self) {
+                unsafe {
+                    // If the struct that owns the RSA reference is dropped
+                    // we remove RSA in static for safety
+                    if self.owns_rsa {
+                        log::debug!("Freeing RSA from acceptor");
+                        RSA_REF = core::mem::transmute(None::<RSA>);
+                    }
+                }
+            }
+        }
+
+        impl<'d, D, const N: usize, const TX_SZ: usize, const RX_SZ: usize>
+            TlsAcceptor<'d, D, N, TX_SZ, RX_SZ>
+        where
+            D: embassy_net::driver::Driver,
+        {
+            pub async fn new(
+                tcp: &'d Tcp<'d, D, N, TX_SZ, RX_SZ>,
+                port: u16,
+                version: TlsVersion,
+                certificates: Certificates<'d>,
+            ) -> Self {
+                let acceptor = tcp
+                    .bind(SocketAddr::V4(SocketAddrV4::new(
+                        Ipv4Addr::new(0, 0, 0, 0),
+                        port,
+                    )))
+                    .await
+                    .unwrap();
+                Self {
+                    acceptor,
+                    version,
+                    certificates,
+                    owns_rsa: false,
+                }
+            }
+
+            /// Enable the use of the hardware accelerated RSA peripheral for the lifetime of
+            /// [TlsAcceptor].
+            ///
+            /// # Arguments
+            ///
+            /// * `rsa` - The RSA peripheral from the HAL
+            pub fn with_hardware_rsa(mut self, rsa: impl Peripheral<P = RSA>) -> Self {
+                unsafe { RSA_REF = core::mem::transmute(Some(Rsa::new(rsa, None))) }
+                self.owns_rsa = true;
+                self
+            }
+        }
+
+        impl<T, const BUFFER_SIZE: usize> edge_nal::Readable for AsyncConnectedSession<T, BUFFER_SIZE>
+        where
+            T: embedded_io_async::Read + embedded_io_async::Write,
+        {
+            async fn readable(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+        }
+
+        impl<'d, D, const N: usize, const TX_SZ: usize, const RX_SZ: usize> edge_nal::TcpAccept
+            for TlsAcceptor<'d, D, N, TX_SZ, RX_SZ>
+        where
+            D: embassy_net::driver::Driver,
+        {
+            type Error = TlsError;
+            type Socket<'a> = AsyncConnectedSession<TcpSocket<'a, N, TX_SZ, RX_SZ>, RX_SZ> where Self: 'a;
+
+            async fn accept(
+                &self,
+            ) -> Result<(SocketAddr, Self::Socket<'_>), <Self as edge_nal::TcpAccept>::Error>
+            {
+                let (addr, socket) = self
+                    .acceptor
+                    .accept()
+                    .await
+                    .map_err(|e| TlsError::TcpError(e))?;
+                log::debug!("Accepted new connection on socket");
+
+                let session: Session<_, RX_SZ> =
+                    Session::new(socket, "", Mode::Server, self.version, self.certificates)?;
+
+                log::debug!("Establishing SSL connection");
+                let connected_session = session.connect().await?;
+
+                Ok((addr, connected_session))
+            }
         }
     }
 }

--- a/examples/edge_server.rs
+++ b/examples/edge_server.rs
@@ -1,0 +1,226 @@
+//! Example for an HTTPS server using [edge-http](https://github.com/ivmarkov/edge-net) as the
+//! HTTPS server implementation, and `esp-mbedtls` for the TLS layer.
+//!
+//! Note: If you run out of heap memory, you need to increase `heap_size` in cfg.toml
+//!
+//! This example uses self-signed certificate. Your browser may display an error.
+//! You have to enable the exception to then proceed, of if using curl, use the flag `-k`.
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+#[doc(hidden)]
+pub use esp_hal as hal;
+
+use edge_http::io::server::{Connection, Handler, Server};
+use edge_http::io::Error;
+use edge_http::Method;
+use edge_nal_embassy::{Tcp, TcpBuffers};
+
+use embedded_io_async::{ErrorType, Read, Write};
+
+use embassy_net::{Config, Stack, StackResources};
+
+use embassy_executor::Spawner;
+use embassy_time::{Duration, Timer};
+use esp_backtrace as _;
+use esp_mbedtls::{set_debug, Certificates, TlsVersion};
+use esp_mbedtls::{TlsError, X509};
+use esp_println::logger::init_logger;
+use esp_println::println;
+use esp_wifi::wifi::{
+    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+    WifiState,
+};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::{
+    clock::ClockControl,
+    peripherals::Peripherals,
+    prelude::*,
+    rng::Rng,
+    system::SystemControl,
+    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
+};
+use static_cell::make_static;
+
+const SSID: &str = env!("SSID");
+const PASSWORD: &str = env!("PASSWORD");
+
+/// Number of sockets used for the HTTPS server
+const SERVER_SOCKETS: usize = 2;
+
+/// Total number of sockets used for the application
+const SOCKET_COUNT: usize = 1 + 1 + SERVER_SOCKETS; // DHCP + DNS + Server
+
+/// HTTPS server evaluated at compile time with socket count and buffer size.
+pub type HttpsServer = Server<SERVER_SOCKETS, 2048, 32>;
+
+#[main]
+async fn main(spawner: Spawner) -> ! {
+    init_logger(log::LevelFilter::Info);
+
+    let mut peripherals = Peripherals::take();
+    let system = SystemControl::new(peripherals.SYSTEM);
+    let clocks = ClockControl::max(system.clock_control).freeze();
+
+    #[cfg(target_arch = "xtensa")]
+    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        PeriodicTimer::new(timer.into()),
+        Rng::new(peripherals.RNG),
+        peripherals.RADIO_CLK,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = peripherals.WIFI;
+    let (wifi_interface, controller) =
+        esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, None);
+    let oneshot_timer = make_static!([OneShotTimer::new(timer_group0.timer0.into())]);
+    esp_hal_embassy::init(&clocks, oneshot_timer);
+
+    let config = Config::dhcpv4(Default::default());
+
+    let seed = 1234; // very random, very secure seed
+
+    // Init network stack
+    let stack = &*make_static!(Stack::new(
+        wifi_interface,
+        config,
+        make_static!(StackResources::<SOCKET_COUNT>::new()),
+        seed
+    ));
+
+    spawner.spawn(connection(controller)).ok();
+    spawner.spawn(net_task(&stack)).ok();
+
+    loop {
+        if stack.is_link_up() {
+            break;
+        }
+        Timer::after(Duration::from_millis(500)).await;
+    }
+
+    println!("Waiting to get IP address...");
+    loop {
+        if let Some(config) = stack.config_v4() {
+            println!("Got IP: {}", config.address);
+            println!(
+                "Point your browser to https://{}/",
+                config.address.address()
+            );
+            break;
+        }
+        Timer::after(Duration::from_millis(500)).await;
+    }
+
+    set_debug(0);
+
+    let server = make_static!(HttpsServer::new());
+    let buffers = make_static!(TcpBuffers::<SERVER_SOCKETS, 2048, 2048>::new());
+    let tcp = make_static!(Tcp::new(stack, buffers));
+
+    let certificates = Certificates {
+        // Use self-signed certificates
+        certificate: X509::pem(concat!(include_str!("./certs/certificate.pem"), "\0").as_bytes())
+            .ok(),
+        private_key: X509::pem(concat!(include_str!("./certs/private_key.pem"), "\0").as_bytes())
+            .ok(),
+        ..Default::default()
+    };
+
+    loop {
+        let tls_acceptor =
+            esp_mbedtls::asynch::TlsAcceptor::new(tcp, 443, TlsVersion::Tls1_2, certificates)
+                .await
+                .with_hardware_rsa(&mut peripherals.RSA);
+        match server.run(tls_acceptor, HttpHandler, Some(15_000)).await {
+            Ok(_) => {}
+            Err(Error::Io(TlsError::MbedTlsError(-30592))) => {
+                println!("Fatal message: Please enable the exception for a self-signed certificate in your browser");
+            }
+            Err(error) => {
+                panic!("{:?}", error);
+            }
+        }
+    }
+}
+
+struct HttpHandler;
+
+impl<'b, T, const N: usize> Handler<'b, T, N> for HttpHandler
+where
+    T: Read + Write,
+    T::Error: Send + Sync,
+{
+    type Error = Error<<T as ErrorType>::Error>;
+
+    async fn handle(&self, connection: &mut Connection<'b, T, N>) -> Result<(), Self::Error> {
+        println!("Got new connection");
+        let headers = connection.headers()?;
+
+        if !matches!(headers.method, Some(Method::Get)) {
+            connection
+                .initiate_response(405, Some("Method Not Allowed"), &[])
+                .await?;
+        } else if !matches!(headers.path, Some("/")) {
+            connection
+                .initiate_response(404, Some("Not Found"), &[])
+                .await?;
+        } else {
+            connection
+                .initiate_response(200, Some("OK"), &[("Content-Type", "text/plain")])
+                .await?;
+
+            connection.write_all(b"Hello world!").await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[embassy_executor::task]
+async fn connection(mut controller: WifiController<'static>) {
+    println!("start connection task");
+    println!("Device capabilities: {:?}", controller.get_capabilities());
+    loop {
+        match esp_wifi::wifi::get_wifi_state() {
+            WifiState::StaConnected => {
+                // wait until we're no longer connected
+                controller.wait_for_event(WifiEvent::StaDisconnected).await;
+                Timer::after(Duration::from_millis(5000)).await
+            }
+            _ => {}
+        }
+        if !matches!(controller.is_started(), Ok(true)) {
+            let client_config = Configuration::Client(ClientConfiguration {
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
+                ..Default::default()
+            });
+            controller.set_configuration(&client_config).unwrap();
+            println!("Starting wifi");
+            controller.start().await.unwrap();
+            println!("Wifi started!");
+        }
+        println!("About to connect...");
+
+        match controller.connect().await {
+            Ok(_) => println!("Wifi connected!"),
+            Err(e) => {
+                println!("Failed to connect to wifi: {e:?}");
+                Timer::after(Duration::from_millis(5000)).await
+            }
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
+    stack.run().await
+}

--- a/justfile
+++ b/justfile
@@ -14,4 +14,5 @@ check arch toolchain:
     cargo +{{ toolchain }} b{{ arch }} --release --example sync_server_mTLS
     cargo +{{ toolchain }} b{{ arch }} --release --example async_server --features="async,esp-hal-embassy"
     cargo +{{ toolchain }} b{{ arch }} --release --example async_server_mTLS --features="async,esp-hal-embassy"
+    cargo +{{ toolchain }} b{{ arch }} --release --example edge_server --features="async,esp-hal-embassy,edge-nal-embassy,edge-http,esp-mbedtls/edge-nal"
     cargo +{{ toolchain }} fmt --all -- --check


### PR DESCRIPTION
This PR provides an implementation of [edge_nal::TcpAccept](https://github.com/ivmarkov/edge-net/blob/640a4f263986d6d26e2508cdb2f43c8ee5a7bd66/edge-nal/src/stack/tcp.rs#L68-L83) to use `esp-mbedtls` with `edge-net`.

As for now, the trait is simply a wrapper over the [edge_nal::TcpAccept implementation](https://github.com/ivmarkov/edge-net/blob/640a4f263986d6d26e2508cdb2f43c8ee5a7bd66/edge-nal-embassy/src/tcp.rs#L63-L91) from `edge-nal-embassy`. 

I also provided an example that uses `edge-http` in server mode for testing, and ensuring compatibility.

Further down the line, other traits will also get their implementation, in subsequent PRs, as I (or any contributor) come around a use case for them.