### PR TITLE
Update esp-hal to `0.20.1`. Decompose RX, TX buffer sizes. Fix examples.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -47,12 +47,12 @@ xtask = "run --manifest-path ./xtask/Cargo.toml --"
 # Alias' for quickly building for different chips or running examples
 # By default we enable
 #   - `default` HAL features to set up basic chip specific settings
-esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default"
-esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default"
-esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default"
-esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default"
+esp32 =   "run --release --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default"
+esp32s2 = "run --release --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default"
+esp32s3 = "run --release --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default"
+esp32c3 = "run --release --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default"
 
-besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default"
-besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default"
-besp32s3 = "build --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default"
-besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default"
+besp32 =   "build --release --features   esp32 --target xtensa-esp32-none-elf        --features esp-hal/default"
+besp32s2 = "build --release --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp-hal/default"
+besp32s3 = "build --release --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp-hal/default"
+besp32c3 = "build --release --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp-hal/default"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,17 @@ lto = false
 opt-level = 3
 
 [dependencies]
-esp-hal = { version = "0.19.0" }
-esp-backtrace = { version = "0.13.0", features = [
+esp-hal = { version = "0.20.1" }
+esp-backtrace = { version = "0.14.0", features = [
     "panic-handler",
     "println",
     "exception-handler",
 ] }
-esp-println = { version = "0.10.0", features = ["log"] }
-esp-hal-embassy = { version = "0.2.0", optional = true }
+esp-println = { version = "0.11.0", features = ["log"] }
+esp-hal-embassy = { version = "0.3.0", optional = true }
 
 embassy-time = { version = "0.3.0", optional = true }
-embassy-executor = { version = "0.5.0", package = "embassy-executor", features = [
+embassy-executor = { version = "0.6.0", package = "embassy-executor", features = [
     "nightly",
     "integrated-timers",
 ], optional = true }
@@ -42,7 +42,7 @@ embassy-net = { version = "0.4.0", features = [
 ], optional = true }
 
 
-esp-wifi = { version = "0.7.1", features = [
+esp-wifi = { version = "0.8.0", features = [
     "phy-enable-usb",
     "embedded-svc",
     "wifi-default",
@@ -69,6 +69,7 @@ esp-mbedtls = { path = "./esp-mbedtls" }
 
 edge-http = { package = "edge-http", git = "https://github.com/ivmarkov/edge-net/", optional = true }
 edge-nal-embassy = { package = "edge-nal-embassy", git = "https://github.com/ivmarkov/edge-net/", optional = true }
+cfg-if = "1.0.0"
 
 [[example]]
 name = "crypto_self_test"

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4.17"
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.0", optional = true }
 crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"] }
-esp-hal = { version = "0.19.0" }
+esp-hal = { version = "0.20.1" }
 cfg-if = "1.0.0"
 edge-nal = { package = "edge-nal", git = "https://github.com/ivmarkov/edge-net/", optional = true }
 edge-nal-embassy = { package = "edge-nal-embassy", git = "https://github.com/ivmarkov/edge-net/", optional = true }

--- a/esp-mbedtls/src/compat/edge_nal_compat.rs
+++ b/esp-mbedtls/src/compat/edge_nal_compat.rs
@@ -1,0 +1,190 @@
+use crate::asynch::{AsyncConnectedSession, Session};
+use crate::{Certificates, Mode, Peripheral, Rsa, TlsError, TlsVersion, RSA, RSA_REF};
+use core::{
+    cell::{Cell, RefCell, UnsafeCell},
+    mem::MaybeUninit,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    ptr::NonNull,
+};
+
+use edge_nal::TcpBind;
+use edge_nal_embassy::{Tcp, TcpAccept, TcpSocket};
+
+pub struct TlsAcceptor<
+    'd,
+    D: embassy_net::driver::Driver,
+    const N: usize,
+    const RX_SZ: usize,
+    const TX_SZ: usize,
+> {
+    acceptor: TcpAccept<'d, D, N, TX_SZ, RX_SZ>,
+    version: TlsVersion,
+    certificates: Certificates<'d>,
+    owns_rsa: bool,
+    tls_buffers: &'d TlsBuffers<RX_SZ, TX_SZ>,
+    tls_buffers_ptr: RefCell<NonNull<([u8; RX_SZ], [u8; TX_SZ])>>,
+}
+
+impl<'d, D, const N: usize, const RX_SZ: usize, const TX_SZ: usize> Drop
+    for TlsAcceptor<'d, D, N, RX_SZ, TX_SZ>
+where
+    D: embassy_net::driver::Driver,
+{
+    fn drop(&mut self) {
+        unsafe {
+            // If the struct that owns the RSA reference is dropped
+            // we remove RSA in static for safety
+            if self.owns_rsa {
+                log::debug!("Freeing RSA from acceptor");
+                RSA_REF = core::mem::transmute(None::<RSA>);
+            }
+
+            self.tls_buffers.pool.free(*self.tls_buffers_ptr.get_mut());
+        }
+    }
+}
+
+impl<'d, D, const N: usize, const RX_SZ: usize, const TX_SZ: usize>
+    TlsAcceptor<'d, D, N, RX_SZ, TX_SZ>
+where
+    D: embassy_net::driver::Driver,
+{
+    pub async fn new(
+        tcp: &'d Tcp<'d, D, N, TX_SZ, RX_SZ>,
+        tls_buffers: &'d TlsBuffers<RX_SZ, TX_SZ>,
+        port: u16,
+        version: TlsVersion,
+        certificates: Certificates<'d>,
+    ) -> Self {
+        let acceptor = tcp
+            .bind(SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(0, 0, 0, 0),
+                port,
+            )))
+            .await
+            .unwrap();
+
+        let socket_buffers = tls_buffers.pool.alloc().unwrap();
+
+        Self {
+            acceptor,
+            version,
+            certificates,
+            owns_rsa: false,
+            tls_buffers,
+            tls_buffers_ptr: RefCell::new(socket_buffers),
+        }
+    }
+
+    /// Enable the use of the hardware accelerated RSA peripheral for the lifetime of
+    /// [TlsAcceptor].
+    ///
+    /// # Arguments
+    ///
+    /// * `rsa` - The RSA peripheral from the HAL
+    pub fn with_hardware_rsa(mut self, rsa: impl Peripheral<P = RSA>) -> Self {
+        unsafe { RSA_REF = core::mem::transmute(Some(Rsa::new(rsa))) }
+        self.owns_rsa = true;
+        self
+    }
+}
+
+impl<'a, T, const RX_SIZE: usize, const TX_SIZE: usize> edge_nal::Readable
+    for AsyncConnectedSession<'a, T, RX_SIZE, TX_SIZE>
+where
+    T: embedded_io_async::Read + embedded_io_async::Write,
+{
+    async fn readable(&mut self) -> Result<(), Self::Error> {
+        unimplemented!();
+    }
+}
+
+impl<'d, D, const N: usize, const RX_SZ: usize, const TX_SZ: usize> edge_nal::TcpAccept
+    for TlsAcceptor<'d, D, N, RX_SZ, TX_SZ>
+where
+    D: embassy_net::driver::Driver,
+{
+    type Error = TlsError;
+    type Socket<'a> = AsyncConnectedSession<'a, TcpSocket<'a, N, TX_SZ, RX_SZ>, RX_SZ, TX_SZ> where Self: 'a;
+
+    async fn accept(
+        &self,
+    ) -> Result<(SocketAddr, Self::Socket<'_>), <Self as edge_nal::TcpAccept>::Error> {
+        let (addr, socket) = self
+            .acceptor
+            .accept()
+            .await
+            .map_err(|e| TlsError::TcpError(e))?;
+        log::debug!("Accepted new connection on socket");
+
+        let (rx, tx) = unsafe { self.tls_buffers_ptr.borrow_mut().as_mut() };
+
+        let session: Session<_, RX_SZ, TX_SZ> = Session::new(
+            socket,
+            "",
+            Mode::Server,
+            self.version,
+            self.certificates,
+            rx,
+            tx,
+        )?;
+
+        log::debug!("Establishing SSL connection");
+        let connected_session = session.connect().await?;
+
+        Ok((addr, connected_session))
+    }
+}
+
+/// A struct that holds a pool of TLS buffers
+pub struct TlsBuffers<const RX_SZ: usize, const TX_SZ: usize> {
+    pool: Pool<([u8; RX_SZ], [u8; TX_SZ]), 1>,
+}
+
+impl<const RX_SZ: usize, const TX_SZ: usize> TlsBuffers<RX_SZ, TX_SZ> {
+    /// Create a new `TlsBuffers` instance
+    pub const fn new() -> Self {
+        Self { pool: Pool::new() }
+    }
+}
+
+pub(crate) struct Pool<T, const N: usize> {
+    used: [Cell<bool>; N],
+    data: [UnsafeCell<MaybeUninit<T>>; N],
+}
+
+impl<T, const N: usize> Pool<T, N> {
+    #[allow(clippy::declare_interior_mutable_const)]
+    const VALUE: Cell<bool> = Cell::new(false);
+    const UNINIT: UnsafeCell<MaybeUninit<T>> = UnsafeCell::new(MaybeUninit::uninit());
+
+    const fn new() -> Self {
+        Self {
+            used: [Self::VALUE; N],
+            data: [Self::UNINIT; N],
+        }
+    }
+}
+
+impl<T, const N: usize> Pool<T, N> {
+    fn alloc(&self) -> Option<NonNull<T>> {
+        for n in 0..N {
+            // this can't race because Pool is not Sync.
+            if !self.used[n].get() {
+                self.used[n].set(true);
+                let p = self.data[n].get() as *mut T;
+                return Some(unsafe { NonNull::new_unchecked(p) });
+            }
+        }
+        None
+    }
+
+    /// safety: p must be a pointer obtained from self.alloc that hasn't been freed yet.
+    unsafe fn free(&self, p: NonNull<T>) {
+        let origin = self.data.as_ptr() as *mut T;
+        let n = p.as_ptr().offset_from(origin);
+        assert!(n >= 0);
+        assert!((n as usize) < N);
+        self.used[n as usize].set(false);
+    }
+}

--- a/esp-mbedtls/src/compat/mod.rs
+++ b/esp-mbedtls/src/compat/mod.rs
@@ -1,6 +1,10 @@
 use core::ffi::VaListImpl;
 use core::fmt::Write;
 
+/// Implements edge-nal traits
+#[cfg(feature = "edge-nal")]
+pub mod edge_nal_compat;
+
 #[no_mangle]
 pub unsafe extern "C" fn snprintf(dst: *mut u8, n: u32, format: *const u8, args: ...) -> i32 {
     vsnprintf(dst, n, format, args)

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 #[doc(hidden)]
 pub use esp_hal as hal;
@@ -23,19 +24,15 @@ use esp_wifi::wifi::{
 };
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    rng::Rng,
-    system::SystemControl,
-    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
+    clock::ClockControl, peripherals::Peripherals, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
 };
 use static_cell::make_static;
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 
-#[main]
+#[esp_hal_embassy::main]
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
@@ -43,13 +40,11 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,
@@ -60,9 +55,16 @@ async fn main(spawner: Spawner) -> ! {
     let (wifi_interface, controller) =
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, None);
-    let oneshot_timer = make_static!([OneShotTimer::new(timer_group0.timer0.into())]);
-    esp_hal_embassy::init(&clocks, oneshot_timer);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+            esp_hal_embassy::init(&clocks, timg1.timer0);
+        } else {
+            use esp_hal::timer::systimer::{SystemTimer, Target};
+            let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
+            esp_hal_embassy::init(&clocks, systimer.alarm0);
+        }
+    }
 
     let config = Config::dhcpv4(Default::default());
 

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 #[doc(hidden)]
 pub use esp_hal as hal;
@@ -26,19 +27,15 @@ use esp_wifi::wifi::{
 };
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    rng::Rng,
-    system::SystemControl,
-    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
+    clock::ClockControl, peripherals::Peripherals, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
 };
 use static_cell::make_static;
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 
-#[main]
+#[esp_hal_embassy::main]
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
@@ -46,13 +43,11 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,
@@ -63,9 +58,16 @@ async fn main(spawner: Spawner) -> ! {
     let (wifi_interface, controller) =
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, None);
-    let oneshot_timer = make_static!([OneShotTimer::new(timer_group0.timer0.into())]);
-    esp_hal_embassy::init(&clocks, oneshot_timer);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+            esp_hal_embassy::init(&clocks, timg1.timer0);
+        } else {
+            use esp_hal::timer::systimer::{SystemTimer, Target};
+            let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
+            esp_hal_embassy::init(&clocks, systimer.alarm0);
+        }
+    }
 
     let config = Config::dhcpv4(Default::default());
 

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -84,6 +84,8 @@ async fn main(spawner: Spawner) -> ! {
 
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
+    let tls_rx_buffer = make_static!([0; 4096]);
+    let tls_tx_buffer = make_static!([0; 2048]);
 
     loop {
         if stack.is_link_up() {
@@ -145,8 +147,8 @@ async fn main(spawner: Spawner) -> ! {
                 .ok(),
                 ..Default::default()
             },
-            make_static!([0; 4096]),
-            make_static!([0; 4096]),
+            tls_rx_buffer,
+            tls_tx_buffer,
         )
         .unwrap()
         .with_hardware_rsa(&mut peripherals.RSA);

--- a/examples/async_server_mTLS.rs
+++ b/examples/async_server_mTLS.rs
@@ -22,6 +22,7 @@
 #![no_std]
 #![no_main]
 #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 #![allow(non_snake_case)]
 
 #[doc(hidden)]
@@ -43,19 +44,15 @@ use esp_wifi::wifi::{
 };
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::{
-    clock::ClockControl,
-    peripherals::Peripherals,
-    prelude::*,
-    rng::Rng,
-    system::SystemControl,
-    timer::{timg::TimerGroup, OneShotTimer, PeriodicTimer},
+    clock::ClockControl, peripherals::Peripherals, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
 };
 use static_cell::make_static;
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 
-#[main]
+#[esp_hal_embassy::main]
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
@@ -63,13 +60,11 @@ async fn main(spawner: Spawner) -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,
@@ -80,9 +75,16 @@ async fn main(spawner: Spawner) -> ! {
     let (wifi_interface, controller) =
         esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, None);
-    let oneshot_timer = make_static!([OneShotTimer::new(timer_group0.timer0.into())]);
-    esp_hal_embassy::init(&clocks, oneshot_timer);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+            esp_hal_embassy::init(&clocks, timg1.timer0);
+        } else {
+            use esp_hal::timer::systimer::{SystemTimer, Target};
+            let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
+            esp_hal_embassy::init(&clocks, systimer.alarm0);
+        }
+    }
 
     let config = Config::dhcpv4(Default::default());
 

--- a/examples/async_server_mTLS.rs
+++ b/examples/async_server_mTLS.rs
@@ -101,6 +101,8 @@ async fn main(spawner: Spawner) -> ! {
 
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
+    let tls_rx_buffer = make_static!([0; 4096]);
+    let tls_tx_buffer = make_static!([0; 2048]);
 
     loop {
         if stack.is_link_up() {
@@ -164,8 +166,8 @@ async fn main(spawner: Spawner) -> ! {
                 .ok(),
                 ..Default::default()
             },
-            make_static!([0; 4096]),
-            make_static!([0; 4096]),
+            tls_rx_buffer,
+            tls_tx_buffer,
         )
         .unwrap()
         .with_hardware_rsa(&mut peripherals.RSA);

--- a/examples/crypto_self_test.rs
+++ b/examples/crypto_self_test.rs
@@ -14,6 +14,7 @@ use esp_println::{logger::init_logger, println};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::{
     clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
+    timer::timg::TimerGroup,
 };
 
 #[entry]
@@ -25,13 +26,11 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    let _ = initialize(
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
+    initialize(
         EspWifiInitFor::Wifi,
-        timer,
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/sync_client.rs
+++ b/examples/sync_client.rs
@@ -19,7 +19,7 @@ use esp_wifi::{
 };
 use hal::{
     clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
-    timer::PeriodicTimer,
+    timer::timg::TimerGroup,
 };
 use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
@@ -34,13 +34,11 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/sync_client_mTLS.rs
+++ b/examples/sync_client_mTLS.rs
@@ -19,7 +19,7 @@ use esp_wifi::{
 };
 use hal::{
     clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
-    timer::PeriodicTimer,
+    timer::timg::TimerGroup,
 };
 use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
@@ -34,13 +34,11 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/sync_server.rs
+++ b/examples/sync_server.rs
@@ -22,7 +22,7 @@ use esp_wifi::{
 };
 use hal::{
     clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
-    timer::PeriodicTimer,
+    timer::timg::TimerGroup,
 };
 use smoltcp::iface::SocketStorage;
 
@@ -37,13 +37,11 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/examples/sync_server_mTLS.rs
+++ b/examples/sync_server_mTLS.rs
@@ -39,7 +39,7 @@ use esp_wifi::{
 };
 use hal::{
     clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
-    timer::PeriodicTimer,
+    timer::timg::TimerGroup,
 };
 use smoltcp::iface::SocketStorage;
 
@@ -54,13 +54,11 @@ fn main() -> ! {
     let system = SystemControl::new(peripherals.SYSTEM);
     let clocks = ClockControl::max(system.clock_control).freeze();
 
-    #[cfg(target_arch = "xtensa")]
-    let timer = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0;
-    #[cfg(target_arch = "riscv32")]
-    let timer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+
     let init = initialize(
         EspWifiInitFor::Wifi,
-        PeriodicTimer::new(timer.into()),
+        timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
         &clocks,

--- a/justfile
+++ b/justfile
@@ -6,13 +6,13 @@ all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-202
     
 [private]
 check arch toolchain:
-    cargo +{{ toolchain }} b{{ arch }} --release --example sync_client
-    cargo +{{ toolchain }} b{{ arch }} --release --example sync_client_mTLS
-    cargo +{{ toolchain }} b{{ arch }} --release --example async_client --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --release --example async_client_mTLS --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --release --example sync_server
-    cargo +{{ toolchain }} b{{ arch }} --release --example sync_server_mTLS
-    cargo +{{ toolchain }} b{{ arch }} --release --example async_server --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --release --example async_server_mTLS --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --release --example edge_server --features="async,esp-hal-embassy,edge-nal-embassy,edge-http,esp-mbedtls/edge-nal"
+    cargo +{{ toolchain }} b{{ arch }} --example sync_client
+    cargo +{{ toolchain }} b{{ arch }} --example sync_client_mTLS
+    cargo +{{ toolchain }} b{{ arch }} --example async_client --features="async,esp-hal-embassy"
+    cargo +{{ toolchain }} b{{ arch }} --example async_client_mTLS --features="async,esp-hal-embassy"
+    cargo +{{ toolchain }} b{{ arch }} --example sync_server
+    cargo +{{ toolchain }} b{{ arch }} --example sync_server_mTLS
+    cargo +{{ toolchain }} b{{ arch }} --example async_server --features="async,esp-hal-embassy"
+    cargo +{{ toolchain }} b{{ arch }} --example async_server_mTLS --features="async,esp-hal-embassy"
+    cargo +{{ toolchain }} b{{ arch }} --example edge_server --features="async,esp-hal-embassy,edge-nal-embassy,edge-http,esp-mbedtls/edge-nal"
     cargo +{{ toolchain }} fmt --all -- --check


### PR DESCRIPTION
This PR provides the following changes:

- Update esp-hal to `0.20.1`.
- The RX and TX buffers can now be set to use independent sizes.
- Re-order rx, tx according to discussed API guidelines.
- Fix `edge_server.rs` example by using a buffer pool like in `edge_nal_embassy`.
- Fix async server examples who called `make_static!()` more than once.
- Change xtask aliases to always build in release mode
- Move `edge_nal_compat` module to its own file to declutter `lib.rs`

Closes #44 