### PR TITLE
fix(async_internal_read): Ensure that all pending data has been processed before returning `Ok(0)`

### DIFF
--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -924,7 +924,10 @@ pub mod asynch {
                     }
                 }
 
-                if !self.rx_buffer.empty() || mbedtls_ssl_get_bytes_avail(self.ssl_context) > 0 {
+                if !self.rx_buffer.empty()
+                    || mbedtls_ssl_check_pending(self.ssl_context) == 1
+                    || mbedtls_ssl_get_bytes_avail(self.ssl_context) > 0
+                {
                     log::debug!("<<< read data from mbedtls");
                     let res = mbedtls_ssl_read(self.ssl_context, buf.as_mut_ptr(), buf.len());
                     log::debug!("<<< mbedtls returned {res}");


### PR DESCRIPTION
This fixes a weird issue I was having while making TLS connections as a client, where `Ok(0)` could be returned early from `async_internal_read()`, while there are still records to be processed from the ssl context.