### PR TITLE
Update esp-hal to `0.21.0`. Update esp-wifi to `0.10.1`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,7 +38,7 @@ rustflags = [
 ]
 
 [unstable]
-build-std = ["core"]
+build-std = ["core", "alloc"]
 
 [alias]
 xtask = "run --manifest-path ./xtask/Cargo.toml --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: nightly-2024-06-12
+          toolchain: nightly-2024-07-22
           components: rust-src,rustfmt
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ lto = false
 opt-level = 3
 
 [dependencies]
-esp-hal = { version = "0.20.1" }
+esp-hal = { version = "0.21.0" }
 esp-backtrace = { version = "0.14.0", features = [
     "panic-handler",
     "println",
     "exception-handler",
 ] }
-esp-println = { version = "0.11.0", features = ["log"] }
-esp-hal-embassy = { version = "0.3.0", optional = true }
+esp-println = { version = "0.12.0", features = ["log"] }
+esp-hal-embassy = { version = "0.4.0", optional = true }
 
 embassy-time = { version = "0.3.0", optional = true }
 embassy-executor = { version = "0.6.0", package = "embassy-executor", features = [
@@ -42,9 +42,8 @@ embassy-net = { version = "0.4.0", features = [
 ], optional = true }
 
 
-esp-wifi = { version = "0.9.1", features = [
+esp-wifi = { version = "0.10.1", features = [
     "phy-enable-usb",
-    "embedded-svc",
     "wifi-default",
 ] }
 smoltcp = { version = "0.11.0", default-features = false, features = [
@@ -70,10 +69,11 @@ esp-mbedtls = { path = "./esp-mbedtls" }
 edge-http = { version = "0.3.0", optional = true }
 edge-nal-embassy = { version = "0.3.0", optional = true }
 cfg-if = "1.0.0"
+esp-alloc = "0.5.0"
 
 [[example]]
 name = "crypto_self_test"
-required-features = ["esp-wifi/wifi-logs"]
+required-features = ["esp-wifi/sys-logs"]
 
 [[example]]
 name = "async_client"
@@ -98,6 +98,7 @@ required-features = ["async", "esp-hal-embassy", "edge-nal-embassy", "edge-http"
 [features]
 esp32 = [
     "esp-hal/esp32",
+    "esp-hal-embassy?/esp32",
     "esp-backtrace/esp32",
     "esp-println/esp32",
     "esp-wifi/esp32",
@@ -105,6 +106,7 @@ esp32 = [
 ]
 esp32c3 = [
     "esp-hal/esp32c3",
+    "esp-hal-embassy?/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-println/esp32c3",
     "esp-wifi/esp32c3",
@@ -112,6 +114,7 @@ esp32c3 = [
 ]
 esp32s2 = [
     "esp-hal/esp32s2",
+    "esp-hal-embassy?/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-println/esp32s2",
     "esp-wifi/esp32s2",
@@ -119,6 +122,7 @@ esp32s2 = [
 ]
 esp32s3 = [
     "esp-hal/esp32s3",
+    "esp-hal-embassy?/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-println/esp32s3",
     "esp-wifi/esp32s3",
@@ -132,5 +136,5 @@ async = [
     "embassy-time",
     "dep:embedded-io-async",
     "esp-mbedtls/async",
-    "esp-hal/async",
+    "esp-hal-embassy"
 ]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SSID=<your_ssid> PASSWORD=<your_password> cargo +esp run --release --example syn
 RISC-V: 
 
 ```shell
-SSID=<your_ssid> PASSWORD=<your_password> cargo +nightly-2023-03-09 run --release --example async_client -F esp32c3,async --target riscv32imc-unknown-none-elf
+SSID=<your_ssid> PASSWORD=<your_password> cargo +nightly run --release --example async_client -F esp32c3,async --target riscv32imc-unknown-none-elf
 ```
 
 Here's a table of the architectures with their corresponding target for quick reference:
@@ -57,7 +57,7 @@ Here's a table of the architectures with their corresponding target for quick re
 | Architecture | Target                      | Toolchain          |
 | ------------ | --------------------------- | ------------------ |
 | esp32        | xtensa-esp32-none-elf       | esp                |
-| esp32c3      | riscv32imc-unknown-none-elf | nightly-2023-03-09 |
+| esp32c3      | riscv32imc-unknown-none-elf | nightly            |
 | esp32s3      | xtensa-esp32s3-none-elf     | esp                |
 
 Heres's a list of all the examples with their description:

--- a/cfg.toml
+++ b/cfg.toml
@@ -1,3 +1,0 @@
-[esp-wifi]
-heap_size = 95000 # use 110k by default
-# heap_size = 73728 # uncomment this to use 72k for esp32-s2/c2

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4.17"
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.0", optional = true }
 crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"] }
-esp-hal = { version = "0.20.1" }
+esp-hal = { version = "0.21.0" }
 cfg-if = "1.0.0"
 edge-nal = { version = "0.3.0", optional = true }
 edge-nal-embassy = { version = "0.3.0", optional = true }

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -16,6 +16,7 @@ use embassy_net::{Config, IpListenEndpoint, Stack, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
+use esp_alloc as _;
 use esp_backtrace as _;
 use esp_mbedtls::{asynch::Session, set_debug, Certificates, Mode, TlsVersion};
 use esp_mbedtls::{TlsError, X509};
@@ -25,11 +26,8 @@ use esp_wifi::wifi::{
     ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
     WifiState,
 };
-use esp_wifi::{initialize, EspWifiInitFor};
-use hal::{
-    clock::ClockControl, peripherals::Peripherals, rng::Rng, system::SystemControl,
-    timer::timg::TimerGroup,
-};
+use esp_wifi::{init, EspWifiInitFor};
+use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
 macro_rules! mk_static {
@@ -48,18 +46,21 @@ const PASSWORD: &str = env!("PASSWORD");
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
-    let mut peripherals = Peripherals::take();
-    let system = SystemControl::new(peripherals.SYSTEM);
-    let clocks = ClockControl::max(system.clock_control).freeze();
+    let mut peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    esp_alloc::heap_allocator!(115 * 1024);
 
-    let init = initialize(
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = init(
         EspWifiInitFor::Wifi,
         timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
-        &clocks,
     )
     .unwrap();
 
@@ -69,12 +70,12 @@ async fn main(spawner: Spawner) -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-            esp_hal_embassy::init(&clocks, timg1.timer0);
+            let timg1 = TimerGroup::new(peripherals.TIMG1);
+            esp_hal_embassy::init(timg1.timer0);
         } else {
             use esp_hal::timer::systimer::{SystemTimer, Target};
             let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-            esp_hal_embassy::init(&clocks, systimer.alarm0);
+            esp_hal_embassy::init(systimer.alarm0);
         }
     }
 

--- a/examples/async_server_mTLS.rs
+++ b/examples/async_server_mTLS.rs
@@ -42,11 +42,8 @@ use esp_wifi::wifi::{
     ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
     WifiState,
 };
-use esp_wifi::{initialize, EspWifiInitFor};
-use hal::{
-    clock::ClockControl, peripherals::Peripherals, rng::Rng, system::SystemControl,
-    timer::timg::TimerGroup,
-};
+use esp_wifi::{init, EspWifiInitFor};
+use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
 macro_rules! mk_static {
@@ -65,18 +62,21 @@ const PASSWORD: &str = env!("PASSWORD");
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
-    let mut peripherals = Peripherals::take();
-    let system = SystemControl::new(peripherals.SYSTEM);
-    let clocks = ClockControl::max(system.clock_control).freeze();
+    let mut peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    esp_alloc::heap_allocator!(115 * 1024);
 
-    let init = initialize(
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = init(
         EspWifiInitFor::Wifi,
         timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
-        &clocks,
     )
     .unwrap();
 
@@ -86,12 +86,12 @@ async fn main(spawner: Spawner) -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-            esp_hal_embassy::init(&clocks, timg1.timer0);
+            let timg1 = TimerGroup::new(peripherals.TIMG1);
+            esp_hal_embassy::init(timg1.timer0);
         } else {
             use esp_hal::timer::systimer::{SystemTimer, Target};
             let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-            esp_hal_embassy::init(&clocks, systimer.alarm0);
+            esp_hal_embassy::init(systimer.alarm0);
         }
     }
 

--- a/examples/edge_server.rs
+++ b/examples/edge_server.rs
@@ -33,11 +33,8 @@ use esp_wifi::wifi::{
     ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
     WifiState,
 };
-use esp_wifi::{initialize, EspWifiInitFor};
-use hal::{
-    clock::ClockControl, peripherals::Peripherals, rng::Rng, system::SystemControl,
-    timer::timg::TimerGroup,
-};
+use esp_wifi::{init, EspWifiInitFor};
+use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
 macro_rules! mk_static {
@@ -68,18 +65,21 @@ pub type HttpsServer = Server<SERVER_SOCKETS, RX_SIZE, 32>;
 async fn main(spawner: Spawner) -> ! {
     init_logger(log::LevelFilter::Info);
 
-    let mut peripherals = Peripherals::take();
-    let system = SystemControl::new(peripherals.SYSTEM);
-    let clocks = ClockControl::max(system.clock_control).freeze();
+    let mut peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    esp_alloc::heap_allocator!(110 * 1024);
 
-    let init = initialize(
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = init(
         EspWifiInitFor::Wifi,
         timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
-        &clocks,
     )
     .unwrap();
 
@@ -89,12 +89,12 @@ async fn main(spawner: Spawner) -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32")] {
-            let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-            esp_hal_embassy::init(&clocks, timg1.timer0);
+            let timg1 = TimerGroup::new(peripherals.TIMG1);
+            esp_hal_embassy::init(timg1.timer0);
         } else {
             use esp_hal::timer::systimer::{SystemTimer, Target};
             let systimer = SystemTimer::new(peripherals.SYSTIMER).split::<Target>();
-            esp_hal_embassy::init(&clocks, systimer.alarm0);
+            esp_hal_embassy::init(systimer.alarm0);
         }
     }
 

--- a/examples/sync_client.rs
+++ b/examples/sync_client.rs
@@ -7,20 +7,18 @@
 pub use esp_hal as hal;
 
 use embedded_io::*;
+use esp_alloc as _;
 use esp_backtrace as _;
 use esp_mbedtls::{set_debug, Mode, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
-    current_millis, initialize,
+    init,
     wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
-use hal::{
-    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
-    timer::timg::TimerGroup,
-};
+use hal::{prelude::*, rng::Rng, time, timer::timg::TimerGroup};
 use smoltcp::{iface::SocketStorage, wire::IpAddress};
 
 const SSID: &str = env!("SSID");
@@ -29,19 +27,21 @@ const PASSWORD: &str = env!("PASSWORD");
 #[entry]
 fn main() -> ! {
     init_logger(log::LevelFilter::Info);
+    let peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
 
-    let peripherals = Peripherals::take();
-    let system = SystemControl::new(peripherals.SYSTEM);
-    let clocks = ClockControl::max(system.clock_control).freeze();
+    esp_alloc::heap_allocator!(115 * 1024);
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = initialize(
+    let init = init(
         EspWifiInitFor::Wifi,
         timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
-        &clocks,
     )
     .unwrap();
 
@@ -49,7 +49,8 @@ fn main() -> ! {
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
         create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+    let now = || time::now().duration_since_epoch().to_millis();
+    let wifi_stack = WifiStack::new(iface, device, sockets, now);
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {

--- a/examples/sync_server_mTLS.rs
+++ b/examples/sync_server_mTLS.rs
@@ -32,15 +32,12 @@ use esp_mbedtls::{set_debug, Mode, TlsError, TlsVersion, X509};
 use esp_mbedtls::{Certificates, Session};
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
-    current_millis, initialize,
+    init,
     wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
-use hal::{
-    clock::ClockControl, peripherals::Peripherals, prelude::*, rng::Rng, system::SystemControl,
-    timer::timg::TimerGroup,
-};
+use hal::{prelude::*, rng::Rng, time, timer::timg::TimerGroup};
 use smoltcp::iface::SocketStorage;
 
 const SSID: &str = env!("SSID");
@@ -50,18 +47,21 @@ const PASSWORD: &str = env!("PASSWORD");
 fn main() -> ! {
     init_logger(log::LevelFilter::Info);
 
-    let mut peripherals = Peripherals::take();
-    let system = SystemControl::new(peripherals.SYSTEM);
-    let clocks = ClockControl::max(system.clock_control).freeze();
+    let mut peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    esp_alloc::heap_allocator!(115 * 1024);
 
-    let init = initialize(
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = init(
         EspWifiInitFor::Wifi,
         timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,
-        &clocks,
     )
     .unwrap();
 
@@ -69,7 +69,8 @@ fn main() -> ! {
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
         create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+    let now = || time::now().duration_since_epoch().to_millis();
+    let wifi_stack = WifiStack::new(iface, device, sockets, now);
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
@@ -132,7 +133,7 @@ fn main() -> ! {
             println!("New connection");
 
             let mut time_out = false;
-            let wait_end = current_millis() + 20 * 1000;
+            let wait_end = now() + 20 * 1000;
             let mut buffer = [0u8; 1024];
             let mut pos = 0;
 
@@ -179,7 +180,7 @@ fn main() -> ! {
                             break;
                         }
 
-                        if current_millis() > wait_end {
+                        if now() > wait_end {
                             println!("Timed out");
                             time_out = true;
                             break;

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 export SSID := "Dummy"
 export PASSWORD := "Dummy"
 
-all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-2024-06-12")
-    cd esp-mbedtls && cargo +nightly-2024-06-12 fmt --all -- --check
+all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-2024-07-22")
+    cd esp-mbedtls && cargo +nightly-2024-07-22 fmt --all -- --check
     
 [private]
 check arch toolchain:


### PR DESCRIPTION
This updates all the `esp-*` dependencies to their latest version and use the new alloc system for Wifi allocations instead of a stack based allocator.

All examples compile fine, but we still need to test the runtime. I did a few tests locally.

@yanshay Can you check if this fixes the issues in https://github.com/esp-rs/esp-mbedtls/issues/42 ?