### PR TITLE
chore: Patch edge-net revision and implement new traits + refactor.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,15 @@ rust-version = "1.75"
 
 [profile.release]
 debug = true
-lto = false
+lto = "fat"
+opt-level = "s"
+
 
 [profile.release.package.esp-wifi]
 opt-level = 3
 
 [profile.dev]
-lto = false
+lto = "fat"
 
 [profile.dev.package.esp-wifi]
 opt-level = 3
@@ -42,10 +44,7 @@ embassy-net = { version = "0.4.0", features = [
 ], optional = true }
 
 
-esp-wifi = { version = "0.10.1", features = [
-    "phy-enable-usb",
-    "wifi-default",
-] }
+esp-wifi = { version = "0.10.1", features = ["phy-enable-usb", "wifi-default"] }
 smoltcp = { version = "0.11.0", default-features = false, features = [
     "proto-igmp",
     "proto-ipv4",
@@ -67,6 +66,7 @@ static_cell = { version = "2.1", features = ["nightly"] }
 esp-mbedtls = { path = "./esp-mbedtls" }
 
 edge-http = { version = "0.3.0", optional = true }
+edge-nal = { version = "0.3.0", optional = true }
 edge-nal-embassy = { version = "0.3.0", optional = true }
 cfg-if = "1.0.0"
 esp-alloc = "0.5.0"
@@ -93,7 +93,7 @@ required-features = ["async"]
 
 [[example]]
 name = "edge_server"
-required-features = ["async", "esp-hal-embassy", "edge-nal-embassy", "edge-http", "esp-mbedtls/edge-nal"]
+required-features = ["async", "edge-server"]
 
 [features]
 esp32 = [
@@ -136,5 +136,19 @@ async = [
     "embassy-time",
     "dep:embedded-io-async",
     "esp-mbedtls/async",
-    "esp-hal-embassy"
+    "esp-hal-embassy",
 ]
+
+# Helper feature to enable all dependencies required for edge-net
+edge-server = [
+    "edge-nal",
+    "edge-nal-embassy",
+    "edge-http",
+    "esp-mbedtls/edge-nal",
+]
+
+# Patch until new release
+[patch.crates-io]
+edge-http = { git = "https://github.com/ivmarkov/edge-net", rev = "f90468953aec1d476ba52fe3b63f392a07bb9daa" }
+edge-nal = { git = "https://github.com/ivmarkov/edge-net", rev = "f90468953aec1d476ba52fe3b63f392a07bb9daa" }
+edge-nal-embassy = { git = "https://github.com/ivmarkov/edge-net", rev = "f90468953aec1d476ba52fe3b63f392a07bb9daa" }

--- a/esp-mbedtls/src/lib.rs
+++ b/esp-mbedtls/src/lib.rs
@@ -107,6 +107,13 @@ impl embedded_io::Error for TlsError {
     }
 }
 
+#[cfg(feature = "edge-nal")]
+impl From<edge_nal_embassy::TcpError> for TlsError {
+    fn from(value: edge_nal_embassy::TcpError) -> Self {
+        TlsError::TcpError(value)
+    }
+}
+
 #[allow(unused)]
 pub fn set_debug(level: u32) {
     #[cfg(not(target_arch = "xtensa"))]
@@ -682,7 +689,7 @@ pub mod asynch {
     pub use crate::compat::edge_nal_compat::*;
 
     pub struct Session<'a, T, const RX_SIZE: usize = 4096, const TX_SIZE: usize = 4096> {
-        stream: T,
+        pub(crate) stream: T,
         drbg_context: *mut mbedtls_ctr_drbg_context,
         ssl_context: *mut mbedtls_ssl_context,
         ssl_config: *mut mbedtls_ssl_config,

--- a/justfile
+++ b/justfile
@@ -8,11 +8,11 @@ all: (check "esp32" "esp") (check "esp32s3" "esp") (check "esp32c3" "nightly-202
 check arch toolchain:
     cargo +{{ toolchain }} b{{ arch }} --example sync_client
     cargo +{{ toolchain }} b{{ arch }} --example sync_client_mTLS
-    cargo +{{ toolchain }} b{{ arch }} --example async_client --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --example async_client_mTLS --features="async,esp-hal-embassy"
+    cargo +{{ toolchain }} b{{ arch }} --example async_client --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --example async_client_mTLS --features="async"
     cargo +{{ toolchain }} b{{ arch }} --example sync_server
     cargo +{{ toolchain }} b{{ arch }} --example sync_server_mTLS
-    cargo +{{ toolchain }} b{{ arch }} --example async_server --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --example async_server_mTLS --features="async,esp-hal-embassy"
-    cargo +{{ toolchain }} b{{ arch }} --example edge_server --features="async,esp-hal-embassy,edge-nal-embassy,edge-http,esp-mbedtls/edge-nal"
+    cargo +{{ toolchain }} b{{ arch }} --example async_server --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --example async_server_mTLS --features="async"
+    cargo +{{ toolchain }} b{{ arch }} --example edge_server --features="async,edge-server"
     cargo +{{ toolchain }} fmt --all -- --check


### PR DESCRIPTION
- Implements the new TcpShutdown trait for closing connections.
- Refactor the handler code to handle the new timeout mecanism.
- Add helper feature to build edge_server example.