### PR TITLE
Update dependencies for `esp-hal`, `esp-wifi` and `embassy-net`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,6 @@ runner = "espflash flash --monitor --baud 921600"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "link-arg=-nostartfiles",
-  "-C", "link-arg=-Trom_functions.x",
 ]
 
 [target.riscv32imc-unknown-none-elf]
@@ -26,7 +25,6 @@ runner = "espflash flash --monitor --baud 921600"
 
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
-  "-C", "link-arg=-Trom_functions.x",
 
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
@@ -39,7 +37,6 @@ runner = "espflash flash --monitor --baud 921600"
 rustflags = [
     #"-C", "linker=rust-lld",    
     "-C", "link-arg=-Tlinkall.x",
-    "-C", "link-arg=-Trom_functions.x",
 ]
 
 [target.xtensa-esp32s3-none-elf]
@@ -48,7 +45,6 @@ runner = "espflash flash --monitor --baud 921600"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "link-arg=-nostartfiles",
-  "-C", "link-arg=-Trom_functions.x",
 ]
 
 [target.'cfg(target_os = "espidf")']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,30 +24,34 @@ opt-level = "z"
 opt-level = 3
 
 [dependencies]
-esp-hal = { version = "0.21.0", optional = true }
+esp-hal = { version = "0.22.0", optional = true }
 esp-backtrace = { version = "0.14.0", optional = true, features = [
     "panic-handler",
     "println",
     "exception-handler",
 ] }
 esp-println = { version = "0.12.0", optional = true, features = ["log"] }
-esp-hal-embassy = { version = "0.4.0", optional = true }
+esp-hal-embassy = { version = "0.5.0", optional = true }
 
 embassy-time = { version = "0.3.0", optional = true }
-embassy-executor = { version = "=0.6.0", package = "embassy-executor", features = [
+embassy-executor = { version = "0.6.3", package = "embassy-executor", features = [
     "nightly",
     "integrated-timers",
 ], optional = true }
-embassy-net = { version = "0.4.0", features = [
+embassy-net = { version = "0.5.0", features = [
     "tcp",
     "udp",
     "dhcpv4",
     "medium-ethernet",
 ], optional = true }
 
-esp-wifi = { version = "0.10.1", optional = true, features = ["phy-enable-usb", "wifi-default", "sys-logs"] }
+blocking-network-stack = { git = "https://github.com/bjoernQ/blocking-network-stack.git", rev = "1c581661d78e0cf0f17b936297179b993fb149d7" }
+esp-wifi = { version = "0.11.0", optional = true, features = [
+    "wifi",
+    "utils",
+    "sys-logs",
+] }
 smoltcp = { version = "0.11.0", optional = true, default-features = false, features = [
-    "proto-igmp",
     "proto-ipv4",
     "socket-tcp",
     "socket-icmp",
@@ -70,7 +74,7 @@ edge-http = { version = "0.3.0", optional = true }
 edge-nal = { version = "0.3.0", optional = true }
 edge-nal-embassy = { version = "0.3.0", optional = true }
 cfg-if = "1.0.0"
-esp-alloc = { version = "0.5.0", optional = true}
+esp-alloc = { version = "0.5.0", optional = true }
 enumset = { version = "1", default-features = false }
 
 [target.'cfg(target_os = "espidf")'.dependencies]
@@ -104,8 +108,26 @@ name = "edge_server"
 required-features = ["examples-async", "edge-http"]
 
 [features]
-examples = ["esp-hal", "esp-backtrace", "esp-println", "esp-wifi", "smoltcp", "esp-alloc"]
-examples-async = ["examples", "esp-hal-embassy", "embassy-time", "embassy-executor", "embassy-net", "edge-http", "edge-nal", "edge-nal-embassy", "esp-wifi/async", "esp-wifi/embassy-net", "esp-mbedtls/async", "esp-mbedtls/edge-nal"]
+examples = [
+    "esp-hal",
+    "esp-backtrace",
+    "esp-println",
+    "esp-wifi",
+    "smoltcp",
+    "esp-alloc",
+]
+examples-async = [
+    "examples",
+    "esp-hal-embassy",
+    "embassy-time",
+    "embassy-executor",
+    "embassy-net",
+    "edge-http",
+    "edge-nal",
+    "edge-nal-embassy",
+    "esp-mbedtls/async",
+    "esp-mbedtls/edge-nal",
+]
 examples-std = ["critical-section/std"]
 
 esp32 = [
@@ -144,16 +166,11 @@ esp32s3 = [
 [build-dependencies]
 embuild = { version = "0.32", features = ["espidf"] }
 
-# Patch until new release
 [patch.crates-io]
-edge-http = { git = "https://github.com/ivmarkov/edge-net" }
-edge-nal = { git = "https://github.com/ivmarkov/edge-net" }
-edge-nal-embassy = { git = "https://github.com/ivmarkov/edge-net" }
+# Patch until https://github.com/ivmarkov/edge-net/pull/50 is merged
+edge-http = { git = "https://github.com/ivmarkov/edge-net", rev = "5a85bcc8b8726e8b7044e9526f01cdba1fd684da" }
+edge-nal = { git = "https://github.com/ivmarkov/edge-net", rev = "5a85bcc8b8726e8b7044e9526f01cdba1fd684da" }
+edge-nal-embassy = { git = "https://github.com/ivmarkov/edge-net", rev = "5a85bcc8b8726e8b7044e9526f01cdba1fd684da" }
 esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc" }
 esp-idf-hal = { git = "https://github.com/esp-rs/esp-idf-hal" }
 esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys" }
-
-# Patch before 0.6.0 got yanked
-embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "886580179ff250e15b0fad6448e8ebed6cdabf2b" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", rev = "886580179ff250e15b0fad6448e8ebed6cdabf2b" }
-embassy-time-queue-driver = { git = "https://github.com/embassy-rs/embassy", rev = "886580179ff250e15b0fad6448e8ebed6cdabf2b" }

--- a/esp-mbedtls-sys/Cargo.toml
+++ b/esp-mbedtls-sys/Cargo.toml
@@ -19,7 +19,7 @@ embuild     = "0.32"
 # For malloc/free
 # TODO: Replace with `esp-alloc` once `esp-alloc` starts to provide `malloc` and `free` in future
 # ... or switch to our own `mbedtls_malloc/free`
-esp-wifi = { version = "0.10.1", default-features = false, optional = true }
+esp-wifi = { version = "0.11.0", default-features = false, optional = true }
 
 # ESP-IDF: The mbedtls lib distributed with ESP-IDF is used
 [target.'cfg(target_os = "espidf")'.dependencies]

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -14,11 +14,11 @@ log = { version = "0.4.17", default-features = false }
 enumset = { version = "1", default-features = false }
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.0", optional = true }
-esp-hal = { version = "0.21.0", optional = true }
+esp-hal = { version = "0.22.0", optional = true }
 # For malloc/free
 # TODO: Replace with `esp-alloc` once `esp-alloc` starts to provide `malloc` and `free` in future
 # ... or switch to our own `mbedtls_malloc/free`
-esp-wifi = { version = "0.10.1", default-features = false, optional = true }
+esp-wifi = { version = "0.11.0", default-features = false, optional = true }
 cfg-if = "1.0.0"
 edge-nal = { version = "0.3.0", optional = true }
 critical-section = "1.1.3"

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -8,8 +8,10 @@
 #[doc(hidden)]
 pub use esp_hal as hal;
 
+use core::net::Ipv4Addr;
+
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, Ipv4Address, Stack, StackResources};
+use embassy_net::{Config, Runner, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
@@ -18,11 +20,14 @@ use esp_mbedtls::{asynch::Session, Certificates, Mode, TlsVersion};
 use esp_mbedtls::{Tls, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{
-    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
-    WifiState,
+use esp_wifi::init;
+use esp_wifi::{
+    wifi::{
+        ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+        WifiState,
+    },
+    EspWifiController,
 };
-use esp_wifi::{init, EspWifiInitFor};
 use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
@@ -52,13 +57,15 @@ async fn main(spawner: Spawner) -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let init = &*mk_static!(
+        EspWifiController<'static>,
+        init(
+            timg0.timer0,
+            Rng::new(peripherals.RNG),
+            peripherals.RADIO_CLK,
+        )
+        .unwrap()
+    );
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
@@ -80,18 +87,15 @@ async fn main(spawner: Spawner) -> ! {
     let seed = 1234; // very random, very secure seed
 
     // Init network stack
-    let stack = &*mk_static!(
-        Stack<WifiDevice<'_, WifiStaDevice>>,
-        Stack::new(
-            wifi_interface,
-            config,
-            mk_static!(StackResources<3>, StackResources::<3>::new()),
-            seed
-        )
+    let (stack, runner) = embassy_net::new(
+        wifi_interface,
+        config,
+        mk_static!(StackResources<3>, StackResources::<3>::new()),
+        seed,
     );
 
     spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(&stack)).ok();
+    spawner.spawn(net_task(runner)).ok();
 
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
@@ -112,11 +116,11 @@ async fn main(spawner: Spawner) -> ! {
         Timer::after(Duration::from_millis(500)).await;
     }
 
-    let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
     socket.set_timeout(Some(Duration::from_secs(10)));
 
-    let remote_endpoint = (Ipv4Address::new(142, 250, 185, 68), 443); // www.google.com
+    let remote_endpoint = (Ipv4Addr::new(142, 250, 185, 68), 443); // www.google.com
     println!("connecting...");
     let r = socket.connect(remote_endpoint).await;
     if let Err(e) = r {
@@ -185,9 +189,9 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;
@@ -203,12 +207,12 @@ async fn connection(mut controller: WifiController<'static>) {
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");
-            controller.start().await.unwrap();
+            controller.start_async().await.unwrap();
             println!("Wifi started!");
         }
         println!("About to connect...");
 
-        match controller.connect().await {
+        match controller.connect_async().await {
             Ok(_) => println!("Wifi connected!"),
             Err(e) => {
                 println!("Failed to connect to wifi: {e:?}");
@@ -219,6 +223,6 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
-    stack.run().await
+async fn net_task(mut runner: Runner<'static, WifiDevice<'static, WifiStaDevice>>) {
+    runner.run().await
 }

--- a/examples/async_client_mTLS.rs
+++ b/examples/async_client_mTLS.rs
@@ -9,8 +9,10 @@ use embassy_executor::Spawner;
 #[doc(hidden)]
 pub use esp_hal as hal;
 
+use core::net::Ipv4Addr;
+
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, Ipv4Address, Stack, StackResources};
+use embassy_net::{Config, Runner, StackResources};
 
 use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
@@ -18,11 +20,14 @@ use esp_mbedtls::{asynch::Session, Mode, TlsVersion};
 use esp_mbedtls::{Certificates, Tls, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{
-    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
-    WifiState,
+use esp_wifi::init;
+use esp_wifi::{
+    wifi::{
+        ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+        WifiState,
+    },
+    EspWifiController,
 };
-use esp_wifi::{init, EspWifiInitFor};
 use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
@@ -52,13 +57,15 @@ async fn main(spawner: Spawner) -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let init = &*mk_static!(
+        EspWifiController<'static>,
+        init(
+            timg0.timer0,
+            Rng::new(peripherals.RNG),
+            peripherals.RADIO_CLK,
+        )
+        .unwrap()
+    );
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
@@ -80,18 +87,15 @@ async fn main(spawner: Spawner) -> ! {
     let seed = 1234; // very random, very secure seed
 
     // Init network stack
-    let stack = &*mk_static!(
-        Stack<WifiDevice<'_, WifiStaDevice>>,
-        Stack::new(
-            wifi_interface,
-            config,
-            mk_static!(StackResources<3>, StackResources::<3>::new()),
-            seed
-        )
+    let (stack, runner) = embassy_net::new(
+        wifi_interface,
+        config,
+        mk_static!(StackResources<3>, StackResources::<3>::new()),
+        seed,
     );
 
     spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(&stack)).ok();
+    spawner.spawn(net_task(runner)).ok();
 
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
@@ -112,11 +116,11 @@ async fn main(spawner: Spawner) -> ! {
         Timer::after(Duration::from_millis(500)).await;
     }
 
-    let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
     socket.set_timeout(Some(Duration::from_secs(10)));
 
-    let remote_endpoint = (Ipv4Address::new(62, 210, 201, 125), 443); // certauth.cryptomix.com
+    let remote_endpoint = (Ipv4Addr::new(62, 210, 201, 125), 443); // certauth.cryptomix.com
     println!("connecting...");
     let r = socket.connect(remote_endpoint).await;
     if let Err(e) = r {
@@ -190,9 +194,9 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;
@@ -208,12 +212,12 @@ async fn connection(mut controller: WifiController<'static>) {
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");
-            controller.start().await.unwrap();
+            controller.start_async().await.unwrap();
             println!("Wifi started!");
         }
         println!("About to connect...");
 
-        match controller.connect().await {
+        match controller.connect_async().await {
             Ok(_) => println!("Wifi connected!"),
             Err(e) => {
                 println!("Failed to connect to wifi: {e:?}");
@@ -224,6 +228,6 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
-    stack.run().await
+async fn net_task(mut runner: Runner<'static, WifiDevice<'static, WifiStaDevice>>) {
+    runner.run().await
 }

--- a/examples/async_server.rs
+++ b/examples/async_server.rs
@@ -12,7 +12,7 @@
 pub use esp_hal as hal;
 
 use embassy_net::tcp::TcpSocket;
-use embassy_net::{Config, IpListenEndpoint, Stack, StackResources};
+use embassy_net::{Config, IpListenEndpoint, Runner, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
@@ -22,11 +22,14 @@ use esp_mbedtls::{asynch::Session, Certificates, Mode, TlsVersion};
 use esp_mbedtls::{Tls, TlsError, X509};
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::{
-    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
-    WifiState,
+use esp_wifi::init;
+use esp_wifi::{
+    wifi::{
+        ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+        WifiState,
+    },
+    EspWifiController,
 };
-use esp_wifi::{init, EspWifiInitFor};
 use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
@@ -56,13 +59,15 @@ async fn main(spawner: Spawner) -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let init = &*mk_static!(
+        EspWifiController<'static>,
+        init(
+            timg0.timer0,
+            Rng::new(peripherals.RNG),
+            peripherals.RADIO_CLK,
+        )
+        .unwrap()
+    );
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
@@ -84,18 +89,15 @@ async fn main(spawner: Spawner) -> ! {
     let seed = 1234; // very random, very secure seed
 
     // Init network stack
-    let stack = &*mk_static!(
-        Stack<WifiDevice<'_, WifiStaDevice>>,
-        Stack::new(
-            wifi_interface,
-            config,
-            mk_static!(StackResources<3>, StackResources::<3>::new()),
-            seed
-        )
+    let (stack, runner) = embassy_net::new(
+        wifi_interface,
+        config,
+        mk_static!(StackResources<3>, StackResources::<3>::new()),
+        seed,
     );
 
     spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(&stack)).ok();
+    spawner.spawn(net_task(runner)).ok();
 
     let mut tls = Tls::new(peripherals.SHA)
         .unwrap()
@@ -126,7 +128,7 @@ async fn main(spawner: Spawner) -> ! {
         Timer::after(Duration::from_millis(500)).await;
     }
 
-    let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
     socket.set_timeout(Some(Duration::from_secs(10)));
     loop {
         println!("Waiting for connection...");
@@ -232,9 +234,9 @@ async fn main(spawner: Spawner) -> ! {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;
@@ -250,12 +252,12 @@ async fn connection(mut controller: WifiController<'static>) {
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");
-            controller.start().await.unwrap();
+            controller.start_async().await.unwrap();
             println!("Wifi started!");
         }
         println!("About to connect...");
 
-        match controller.connect().await {
+        match controller.connect_async().await {
             Ok(_) => println!("Wifi connected!"),
             Err(e) => {
                 println!("Failed to connect to wifi: {e:?}");
@@ -266,6 +268,6 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
-    stack.run().await
+async fn net_task(mut runner: Runner<'static, WifiDevice<'static, WifiStaDevice>>) {
+    runner.run().await
 }

--- a/examples/crypto_self_test.rs
+++ b/examples/crypto_self_test.rs
@@ -12,7 +12,7 @@ use esp_println::{logger::init_logger, println};
 
 /// Only used for ROM functions
 #[allow(unused_imports)]
-use esp_wifi::{init, EspWifiInitFor};
+use esp_wifi::init;
 use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 pub fn cycles() -> u64 {
@@ -43,7 +43,6 @@ fn main() -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
     let _init = init(
-        EspWifiInitFor::Wifi,
         timg0.timer0,
         Rng::new(peripherals.RNG),
         peripherals.RADIO_CLK,

--- a/examples/edge_server.rs
+++ b/examples/edge_server.rs
@@ -22,7 +22,7 @@ use edge_nal_embassy::{Tcp, TcpBuffers};
 
 use embedded_io_async::{Read, Write};
 
-use embassy_net::{Config, Stack, StackResources};
+use embassy_net::{Config, Runner, StackResources};
 
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
@@ -31,11 +31,14 @@ use esp_mbedtls::{Certificates, Tls, TlsVersion};
 use esp_mbedtls::{TlsError, X509};
 use esp_println::logger::init_logger;
 use esp_println::println;
-use esp_wifi::wifi::{
-    ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
-    WifiState,
+use esp_wifi::init;
+use esp_wifi::{
+    wifi::{
+        ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
+        WifiState,
+    },
+    EspWifiController,
 };
-use esp_wifi::{init, EspWifiInitFor};
 use hal::{prelude::*, rng::Rng, timer::timg::TimerGroup};
 
 // Patch until https://github.com/embassy-rs/static-cell/issues/16 is fixed
@@ -80,13 +83,15 @@ async fn main(spawner: Spawner) -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let init = &*mk_static!(
+        EspWifiController<'static>,
+        init(
+            timg0.timer0,
+            Rng::new(peripherals.RNG),
+            peripherals.RADIO_CLK,
+        )
+        .unwrap()
+    );
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
@@ -108,21 +113,18 @@ async fn main(spawner: Spawner) -> ! {
     let seed = 1234; // very random, very secure seed
 
     // Init network stack
-    let stack = &*mk_static!(
-        Stack<WifiDevice<'_, WifiStaDevice>>,
-        Stack::new(
-            wifi_interface,
-            config,
-            mk_static!(
-                StackResources<SOCKET_COUNT>,
-                StackResources::<SOCKET_COUNT>::new()
-            ),
-            seed
-        )
+    let (stack, runner) = embassy_net::new(
+        wifi_interface,
+        config,
+        mk_static!(
+            StackResources<SOCKET_COUNT>,
+            StackResources::<SOCKET_COUNT>::new()
+        ),
+        seed,
     );
 
     spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(&stack)).ok();
+    spawner.spawn(net_task(runner)).ok();
 
     loop {
         if stack.is_link_up() {
@@ -236,9 +238,9 @@ impl Handler for HttpHandler {
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
     println!("start connection task");
-    println!("Device capabilities: {:?}", controller.get_capabilities());
+    println!("Device capabilities: {:?}", controller.capabilities());
     loop {
-        match esp_wifi::wifi::get_wifi_state() {
+        match esp_wifi::wifi::wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;
@@ -254,12 +256,12 @@ async fn connection(mut controller: WifiController<'static>) {
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");
-            controller.start().await.unwrap();
+            controller.start_async().await.unwrap();
             println!("Wifi started!");
         }
         println!("About to connect...");
 
-        match controller.connect().await {
+        match controller.connect_async().await {
             Ok(_) => println!("Wifi connected!"),
             Err(e) => {
                 println!("Failed to connect to wifi: {e:?}");
@@ -270,6 +272,6 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
-    stack.run().await
+async fn net_task(mut runner: Runner<'static, WifiDevice<'static, WifiStaDevice>>) {
+    runner.run().await
 }

--- a/examples/sync_client.rs
+++ b/examples/sync_client.rs
@@ -6,6 +6,7 @@
 #[doc(hidden)]
 pub use esp_hal as hal;
 
+use blocking_network_stack::Stack;
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_mbedtls::{Certificates, Session};
@@ -14,11 +15,12 @@ use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     init,
     wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
-    wifi_interface::WifiStack,
-    EspWifiInitFor,
 };
 use hal::{prelude::*, rng::Rng, time, timer::timg::TimerGroup};
-use smoltcp::{iface::SocketStorage, wire::IpAddress};
+use smoltcp::{
+    iface::{SocketSet, SocketStorage},
+    wire::{DhcpOption, IpAddress},
+};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -36,20 +38,26 @@ fn main() -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let mut rng = Rng::new(peripherals.RNG);
 
-    let wifi = peripherals.WIFI;
+    let init = init(timg0.timer0, rng.clone(), peripherals.RADIO_CLK).unwrap();
+
+    let mut wifi = peripherals.WIFI;
+    let (iface, device, mut controller) =
+        create_network_interface(&init, &mut wifi, WifiStaDevice).unwrap();
+
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
+    let mut socket_set = SocketSet::new(&mut socket_set_entries[..]);
+    let mut dhcp_socket = smoltcp::socket::dhcpv4::Socket::new();
+    // we can set a hostname here (or add other DHCP options)
+    dhcp_socket.set_outgoing_options(&[DhcpOption {
+        kind: 12,
+        data: b"esp-mbedtls",
+    }]);
+    socket_set.add(dhcp_socket);
+
     let now = || time::now().duration_since_epoch().to_millis();
-    let wifi_stack = WifiStack::new(iface, device, sockets, now);
+    let wifi_stack = Stack::new(iface, device, socket_set, now, rng.random());
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {

--- a/examples/sync_client_mTLS.rs
+++ b/examples/sync_client_mTLS.rs
@@ -6,6 +6,7 @@
 #[doc(hidden)]
 pub use esp_hal as hal;
 
+use blocking_network_stack::Stack;
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_mbedtls::{Certificates, Session};
@@ -14,11 +15,12 @@ use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     init,
     wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
-    wifi_interface::WifiStack,
-    EspWifiInitFor,
 };
 use hal::{prelude::*, rng::Rng, time, timer::timg::TimerGroup};
-use smoltcp::{iface::SocketStorage, wire::IpAddress};
+use smoltcp::{
+    iface::{SocketSet, SocketStorage},
+    wire::{DhcpOption, IpAddress},
+};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -37,20 +39,26 @@ fn main() -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let mut rng = Rng::new(peripherals.RNG);
 
-    let wifi = peripherals.WIFI;
+    let init = init(timg0.timer0, rng.clone(), peripherals.RADIO_CLK).unwrap();
+
+    let mut wifi = peripherals.WIFI;
+    let (iface, device, mut controller) =
+        create_network_interface(&init, &mut wifi, WifiStaDevice).unwrap();
+
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
+    let mut socket_set = SocketSet::new(&mut socket_set_entries[..]);
+    let mut dhcp_socket = smoltcp::socket::dhcpv4::Socket::new();
+    // we can set a hostname here (or add other DHCP options)
+    dhcp_socket.set_outgoing_options(&[DhcpOption {
+        kind: 12,
+        data: b"esp-mbedtls",
+    }]);
+    socket_set.add(dhcp_socket);
+
     let now = || time::now().duration_since_epoch().to_millis();
-    let wifi_stack = WifiStack::new(iface, device, sockets, now);
+    let wifi_stack = Stack::new(iface, device, socket_set, now, rng.random());
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {

--- a/examples/sync_server_mTLS.rs
+++ b/examples/sync_server_mTLS.rs
@@ -26,6 +26,7 @@
 #[doc(hidden)]
 pub use esp_hal as hal;
 
+use blocking_network_stack::Stack;
 use embedded_io::*;
 use esp_backtrace as _;
 use esp_mbedtls::{Certificates, Session};
@@ -34,11 +35,12 @@ use esp_println::{logger::init_logger, print, println};
 use esp_wifi::{
     init,
     wifi::{utils::create_network_interface, ClientConfiguration, Configuration, WifiStaDevice},
-    wifi_interface::WifiStack,
-    EspWifiInitFor,
 };
 use hal::{prelude::*, rng::Rng, time, timer::timg::TimerGroup};
-use smoltcp::iface::SocketStorage;
+use smoltcp::{
+    iface::{SocketSet, SocketStorage},
+    wire::DhcpOption,
+};
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -57,20 +59,26 @@ fn main() -> ! {
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    let init = init(
-        EspWifiInitFor::Wifi,
-        timg0.timer0,
-        Rng::new(peripherals.RNG),
-        peripherals.RADIO_CLK,
-    )
-    .unwrap();
+    let mut rng = Rng::new(peripherals.RNG);
 
-    let wifi = peripherals.WIFI;
+    let init = init(timg0.timer0, rng.clone(), peripherals.RADIO_CLK).unwrap();
+
+    let mut wifi = peripherals.WIFI;
+    let (iface, device, mut controller) =
+        create_network_interface(&init, &mut wifi, WifiStaDevice).unwrap();
+
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
+    let mut socket_set = SocketSet::new(&mut socket_set_entries[..]);
+    let mut dhcp_socket = smoltcp::socket::dhcpv4::Socket::new();
+    // we can set a hostname here (or add other DHCP options)
+    dhcp_socket.set_outgoing_options(&[DhcpOption {
+        kind: 12,
+        data: b"esp-mbedtls",
+    }]);
+    socket_set.add(dhcp_socket);
+
     let now = || time::now().duration_since_epoch().to_millis();
-    let wifi_stack = WifiStack::new(iface, device, sockets, now);
+    let wifi_stack = Stack::new(iface, device, socket_set, now, rng.random());
 
     println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {


### PR DESCRIPTION
Bump dependencies used in examples and in `esp-mbedtls`, and fix examples.