### PR TITLE
chore: upgrade `esp-hal` to `=1.0.0-rc.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ opt-level = "z"
 opt-level = 3
 
 [dependencies]
-esp-hal = { version = "=1.0.0-beta.1", optional = true }
+esp-hal = { version = "=1.0.0-rc.0", optional = true }
 esp-backtrace = { version = "0.16", optional = true, features = [
     "panic-handler",
     "println",
@@ -44,7 +44,7 @@ embassy-net = { version = "0.6.0", features = [
     "medium-ethernet",
 ], optional = true }
 
-esp-wifi = { version = "0.14.0", optional = true, features = [
+esp-wifi = { version = "0.15.0", optional = true, features = [
     "sys-logs",
     "wifi",
 ] }

--- a/esp-mbedtls-sys/Cargo.toml
+++ b/esp-mbedtls-sys/Cargo.toml
@@ -19,7 +19,7 @@ embuild     = "0.33"
 # For malloc/free
 # TODO: Replace with `esp-alloc` once `esp-alloc` starts to provide `malloc` and `free` in future
 # ... or switch to our own `mbedtls_malloc/free`
-esp-wifi = { version = "0.14.0", default-features = false, optional = true }
+esp-wifi = { version = "0.15.0", default-features = false, optional = true }
 
 # ESP-IDF: The mbedtls lib distributed with ESP-IDF is used
 [target.'cfg(target_os = "espidf")'.dependencies]

--- a/esp-mbedtls/Cargo.toml
+++ b/esp-mbedtls/Cargo.toml
@@ -14,11 +14,11 @@ log = { version = "0.4.17", default-features = false }
 enumset = { version = "1", default-features = false }
 embedded-io = { version = "0.6.1" }
 embedded-io-async = { version = "0.6.0", optional = true }
-esp-hal = { version = "=1.0.0-beta.1", features = ["unstable"], optional = true }
+esp-hal = { version = "=1.0.0-rc.0", features = ["unstable"], optional = true }
 # For malloc/free
 # TODO: Replace with `esp-alloc` once `esp-alloc` starts to provide `malloc` and `free` in future
 # ... or switch to our own `mbedtls_malloc/free`
-esp-wifi = { version = "0.14", default-features = false, optional = true }
+esp-wifi = { version = "0.15", default-features = false, optional = true }
 cfg-if = "1.0.0"
 edge-nal = { version = "0.5.0", optional = true }
 critical-section = "1.1.3"


### PR DESCRIPTION
Fixes #83 

Simply bumps up the `esp-hal` and other crates so it compiles. I haven't tested much yet, so opening as draft.

Would appreciate someone else testing also, I'm mostly just going to use this in my project as "testing".