### PR TITLE
Restore support for ESP-IDF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         uses: esp-rs/xtensa-toolchain@v1.6
         with:
           default: true
-          ldproxy: false
+          ldproxy: true
 
       # TODO: Double-check and uncomment
       # - uses: Swatinem/rust-cache@v2
@@ -236,6 +236,65 @@ jobs:
       - name: Build - Examples
         run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo build --no-default-features --features ${{ matrix.mcu[1] }} --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort
 
+  build-esp-idf:
+    name: Build-ESP-IDF
+    runs-on: ubuntu-latest
+    permissions: read-all
+    needs: build-mcu
+    strategy:
+      fail-fast: false
+      matrix:
+        mcu:
+          - [std, esp32, xtensa-esp32-espidf]
+#          - [std, esp32s2, xtensa-esp32s2-espidf]
+          - [std, esp32s3, xtensa-esp32s3-espidf]
+#          - [std, esp32c2, riscv32imc-esp-espidf]
+#          - [std, esp32c3, riscv32imc-esp-espidf]
+#          - [std, esp32c6, riscv32imac-esp-espidf]
+# No Wifi support on esp32h2
+#          - [std, esp32h2, riscv32imac-esp-espidf]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-gnu
+          toolchain: nightly
+          components: rust-src,rustfmt,clippy
+
+      - name: Install MCU target
+        if: startsWith(matrix.mcu[2], 'riscv32')
+        run: rustup target add ${{ matrix.mcu[2] }}
+
+      - name: Install Rust for Xtensa
+        if: startsWith(matrix.mcu[2], 'xtensa-')
+        uses: esp-rs/xtensa-toolchain@v1.6
+        with:
+          default: true
+          ldproxy: true
+
+      # TODO: Double-check and uncomment
+      # - uses: Swatinem/rust-cache@v2
+      #   with:
+      #     workspaces: |
+      #       ./
+      #       xtask
+
+      - name: Clippy
+        run: cargo clippy --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort -- -D warnings
+
+      - name: Build
+        run: cargo build --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort
+
+      - name: Fmt Check - Examples
+        run: cd examples/${{ matrix.mcu[0] }}; cargo fmt -- --check
+
+      - name: Clippy - Examples
+        run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo clippy --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort -- -D warnings
+
+      - name: Build - Examples
+        run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo build --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort
+
   # If libraries are rebuilt and tests are successful, we upload them in a specific job
   # that has write access to prevent security breaches, and unwanted use of the token
   commit-libs:
@@ -243,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: build-mcu
+    needs: build-esp-idf
     # TODO: Currently GitHub doesn't allow pushing to a forked repo's branch when running an action on a PR to upstream.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&

--- a/esp-mbedtls-sys/src/hook/digest/sha1.rs
+++ b/esp-mbedtls-sys/src/hook/digest/sha1.rs
@@ -21,9 +21,9 @@ pub unsafe fn hook_sha1(sha1: Option<&'static (dyn MbedtlsSha1 + Send + Sync)>) 
     critical_section::with(|cs| {
         #[allow(clippy::if_same_then_else)]
         if sha1.is_some() {
-            info!("SHA-1 hook: added custom/HW accelerated impl");
+            debug!("SHA-1 hook: added custom/HW accelerated impl");
         } else {
-            info!("SHA-1 hook: removed");
+            debug!("SHA-1 hook: removed");
         }
 
         alt::SHA1.borrow(cs).set(sha1);

--- a/esp-mbedtls-sys/src/hook/digest/sha256.rs
+++ b/esp-mbedtls-sys/src/hook/digest/sha256.rs
@@ -22,9 +22,9 @@ pub unsafe fn hook_sha256(sha256: Option<&'static (dyn MbedtlsSha256 + Send + Sy
     critical_section::with(|cs| {
         #[allow(clippy::if_same_then_else)]
         if sha256.is_some() {
-            info!("SHA-256 hook: added custom/HW accelerated impl");
+            debug!("SHA-256 hook: added custom/HW accelerated impl");
         } else {
-            info!("SHA-256 hook: removed");
+            debug!("SHA-256 hook: removed");
         }
 
         alt::SHA256.borrow(cs).set(sha256);
@@ -43,9 +43,9 @@ pub unsafe fn hook_sha224(sha224: Option<&'static (dyn MbedtlsSha224 + Send + Sy
     critical_section::with(|cs| {
         #[allow(clippy::if_same_then_else)]
         if sha224.is_some() {
-            info!("SHA-224 hook: added custom/HW accelerated impl");
+            debug!("SHA-224 hook: added custom/HW accelerated impl");
         } else {
-            info!("SHA-224 hook: removed");
+            debug!("SHA-224 hook: removed");
         }
 
         alt::SHA224.borrow(cs).set(sha224);

--- a/esp-mbedtls-sys/src/hook/digest/sha512.rs
+++ b/esp-mbedtls-sys/src/hook/digest/sha512.rs
@@ -22,9 +22,9 @@ pub unsafe fn hook_sha512(sha512: Option<&'static (dyn MbedtlsSha512 + Send + Sy
     critical_section::with(|cs| {
         #[allow(clippy::if_same_then_else)]
         if sha512.is_some() {
-            info!("SHA-512 hook: added custom/HW accelerated impl");
+            debug!("SHA-512 hook: added custom/HW accelerated impl");
         } else {
-            info!("SHA-512 hook: removed");
+            debug!("SHA-512 hook: removed");
         }
 
         alt::SHA512.borrow(cs).set(sha512);
@@ -43,9 +43,9 @@ pub unsafe fn hook_sha384(sha384: Option<&'static (dyn MbedtlsSha384 + Send + Sy
     critical_section::with(|cs| {
         #[allow(clippy::if_same_then_else)]
         if sha384.is_some() {
-            info!("SHA-384 hook: added custom/HW accelerated impl");
+            debug!("SHA-384 hook: added custom/HW accelerated impl");
         } else {
-            info!("SHA-384 hook: removed");
+            debug!("SHA-384 hook: removed");
         }
 
         alt::SHA384.borrow(cs).set(sha384);

--- a/esp-mbedtls-sys/src/hook/exp_mod.rs
+++ b/esp-mbedtls-sys/src/hook/exp_mod.rs
@@ -57,9 +57,9 @@ pub unsafe fn hook_exp_mod(exp_mod: Option<&'static (dyn MbedtlsMpiExpMod + Send
     critical_section::with(|cs| {
         #[allow(clippy::if_same_then_else)]
         if exp_mod.is_some() {
-            info!("RSA-EXP-MOD hook: added custom/HW accelerated impl");
+            debug!("RSA-EXP-MOD hook: added custom/HW accelerated impl");
         } else {
-            info!("RSA-EXP-MOD hook: removed");
+            debug!("RSA-EXP-MOD hook: removed");
         }
 
         alt::EXP_MOD.borrow(cs).set(exp_mod);

--- a/esp-mbedtls-sys/src/lib.rs
+++ b/esp-mbedtls-sys/src/lib.rs
@@ -10,6 +10,7 @@ pub use error::*;
 pub(crate) mod fmt;
 
 mod error;
+#[cfg(not(target_os = "espidf"))]
 mod extra_impls; // TODO: Figure out if we still need this
 
 #[cfg(not(target_os = "espidf"))]

--- a/esp-mbedtls/src/cert.rs
+++ b/esp-mbedtls/src/cert.rs
@@ -1,9 +1,8 @@
 use core::ffi::CStr;
 use core::marker::PhantomData;
 
-use esp_mbedtls_sys::*;
-
-use super::{merr, MRc, SessionError};
+use super::sys::*;
+use super::{MRc, SessionError};
 
 /// Holds a reference to a PEM or DER-encoded X509 certificate or private key.
 ///

--- a/esp-mbedtls/src/session.rs
+++ b/esp-mbedtls/src/session.rs
@@ -2,9 +2,8 @@ use core::ffi::{c_int, c_void, CStr};
 
 use embedded_io::{Error, ErrorKind};
 
-use esp_mbedtls_sys::*;
-
-use super::{mbedtls_rng, merr, Certificate, MBox, PrivateKey, Tls, TlsReference, TlsVersion};
+use super::sys::*;
+use super::{mbedtls_rng, Certificate, MBox, PrivateKey, Tls, TlsReference, TlsVersion};
 
 pub use asynch::*;
 

--- a/esp-mbedtls/src/session/asynch.rs
+++ b/esp-mbedtls/src/session/asynch.rs
@@ -5,11 +5,10 @@ use core::task::{Context, Poll};
 
 use embedded_io::ErrorKind;
 
-use esp_mbedtls_sys::*;
-
 use io::{ErrorType, Read, Write};
 
-use crate::{merr, SessionError, TlsReference};
+use crate::sys::*;
+use crate::{SessionError, TlsReference};
 
 use super::{SessionConfig, SessionState};
 

--- a/esp-mbedtls/src/session/blocking.rs
+++ b/esp-mbedtls/src/session/blocking.rs
@@ -1,10 +1,10 @@
 use core::ffi::{c_int, c_uchar, c_void, CStr};
 
-use esp_mbedtls_sys::*;
-
 use io::{ErrorType, Read, Write};
 
-use super::{merr, SessionConfig, SessionError, SessionState, TlsReference};
+use crate::sys::*;
+
+use super::{SessionConfig, SessionError, SessionState, TlsReference};
 
 /// Re-export of the `embedded-io` crate so that users don't have to explicitly depend on it
 /// to use e.g. `write_all` or `read_exact`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,30 +2,61 @@
 
 The examples currently run on the following platforms:
 
-## STD
+## STD (and ESP-IDF)
 
 Check folder [std](std).
 
-Building:
-```
+Build:
+```sh
 cd examples/std
 cargo build
+```
+
+Build for ESP-IDF*:
+```sh
+export WIFI_SSID="your-wifi-ssid"
+export WIFI_PASS="your-wifi-password"
+export MCU="<your-mcu>"
+cd examples/std
+cargo build --target <esp-idf-target> --Zbuild-std=std,panic_abort
+```
+
+...where:
+- `<your-mcu>` - the ESP32 MCU you would like to build for
+- `<esp-idf-target>` - the ESP-IDF target corresponding to the ESP32 MCU
+
+Supported `esp32xx` MCUs (relevant HW acceleration is automatically enabled by ESP-IDF itself):
+| MCU          | Target                       |
+| ------------ | ---------------------------- |
+| esp32        | xtensa-esp32-espidf          |
+| esp32c2      | riscv32imac-esp-espidf       |
+| esp32c3      | riscv32imc-esp-iespidf       |
+| esp32c6      | riscv32imac-esp-espidf       |
+| esp32h2      | riscv32imac-esp-espidf       |
+| esp32s2      | xtensa-esp32s2-espidf        |
+| esp32s3      | xtensa-esp32s3-espidf        |
+
+(*) **NOTE: Building for xtensa targets requires the usage of the `esp` Rust toolchain, by instaling `espup`, i.e.:**
+```sh
+cargo install espup
+espup install
+rusup default esp
 ```
 
 ## Baremetal ESP32-XX with `esp-hal` and `embassy-net`
 
 Check folder [esp](esp).
 
-Building:
-```
+Build*:
+```sh
 export WIFI_SSID="your-wifi-ssid"
 export WIFI_PASS="your-wifi-password"
 cd examples/esp
 cargo build --no-default-features --features <esp32XX> --target <esp32XX-target>
 ```
 
-To build and run one example, i.e. `client`:
-```
+To build and run one example, i.e. `client`*:
+```sh
 export WIFI_SSID="your-wifi-ssid"
 export WIFI_PASS="your-wifi-password"
 cd examples/esp
@@ -34,9 +65,9 @@ cargo run --bin client --no-default-features --features <esp32XX> --target <esp3
 
 ...where:
 - `<esp32XX>` - the ESP32 MCU you would like to build for
-- `<esp32XX-target>` - the target corresponding to the ESP32MCU
+- `<esp32XX-target>` - the target corresponding to the ESP32 MCU
 
-Supported `esp32xx` MCUs,and their corresponding `<esp32XX-target>` targets:
+Supported `esp32xx` MCUs and their corresponding `<esp32XX-target>` targets:
 | MCU          | Target                       | Hardware Acceleration                            |
 | ------------ | ---------------------------- | ------------------------------------------------ |
 | esp32        | xtensa-esp32-none-elf        | RSA-ExpMod                                       |
@@ -46,6 +77,14 @@ Supported `esp32xx` MCUs,and their corresponding `<esp32XX-target>` targets:
 | esp32h2      | riscv32imac-unknown-none-elf | RSA-ExpMod, SHA1, SHA224, SHA256                 |
 | esp32s2      | xtensa-esp32s2-none-elf      | RSA-ExpMod, SHA1, SHA224, SHA256, SHA384, SHA512 |
 | esp32s3      | xtensa-esp32s3-none-elf      | RSA-ExpMod, SHA1, SHA224, SHA256, SHA384, SHA512 |
+
+(*) **NOTE: Building for xtensa targets requires the usage of the `esp` Rust toolchain, by instaling `espup`, i.e.:**
+```sh
+cargo install espup
+espup install
+rusup default esp
+. ~/export_esp.sh
+```
 
 ## Upcoming soon
 

--- a/examples/common/certs.rs
+++ b/examples/common/certs.rs
@@ -23,7 +23,7 @@ pub fn client_conf<'a>(mtls: bool, server_name: Option<&'a CStr>) -> ClientSessi
 
     if mtls {
         conf.creds = Some(Credentials {
-            certificate: Certificate::new(X509::DER(CERT)).unwrap(),
+            certificate: Certificate::new_no_copy(CERT).unwrap(),
             private_key: esp_mbedtls::PrivateKey::new(X509::DER(KEY), None).unwrap(),
         });
     }
@@ -32,7 +32,7 @@ pub fn client_conf<'a>(mtls: bool, server_name: Option<&'a CStr>) -> ClientSessi
 }
 
 pub fn server_conf(mtls: bool) -> ServerSessionConfig<'static> {
-    let cert = Certificate::new(X509::DER(CERT)).unwrap();
+    let cert = Certificate::new_no_copy(CERT).unwrap();
 
     let mut conf = ServerSessionConfig {
         ca_chain: Some(cert.clone()),
@@ -44,7 +44,7 @@ pub fn server_conf(mtls: bool) -> ServerSessionConfig<'static> {
 
     if mtls {
         // The assumption is that the client would use the same CERT/KEY pair that the server itself uses
-        conf.ca_chain = Some(Certificate::new(X509::DER(CERT)).unwrap());
+        conf.ca_chain = Some(Certificate::new_no_copy(CERT).unwrap());
     }
 
     conf

--- a/examples/esp/.cargo/config.toml
+++ b/examples/esp/.cargo/config.toml
@@ -6,11 +6,11 @@
 target = "riscv32imac-unknown-none-elf"
 
 [target.'cfg(all(target_arch = "riscv32", target_os = "none"))']
-runner = "espflash flash --monitor"
+runner = "espflash flash --baud 921600 --monitor"
 rustflags = ["-C", "link-arg=-Tlinkall.x", "-C", "force-frame-pointers"]
 
 [target.'cfg(all(target_arch = "xtensa", target_os = "none"))']
-runner  = "espflash flash --monitor"
+runner  = "espflash flash --baud 921600 --monitor"
 rustflags = ["-C", "link-arg=-Wl,-Tlinkall.x", "-C", "link-arg=-nostartfiles"]
 
 [unstable]

--- a/examples/std/.cargo/config.toml
+++ b/examples/std/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.'cfg(target_os = "espidf")']
+runner = "espflash flash --baud 921600 --monitor"
+linker = "ldproxy"
+rustflags = ["--cfg", "espidf_time64"]

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.84"
 
+[profile.release]
+debug = true
+opt-level = "s"
+
+[profile.dev]
+debug = true
+opt-level = "z"
+
 [dependencies]
 log = "0.4"
 esp-mbedtls = { path = "../../esp-mbedtls", features = ["log", "edge-nal"] }
@@ -13,16 +21,22 @@ enumset = { version = "1", default-features = false }
 
 # For the `edge_*` examples
 edge-http = { version = "0.7", features = ["io"] }
-edge-nal-std = "0.6"
 
 # STD-only dependencies
-env_logger = "0.11"
 rand = "0.9"
 critical-section = { version = "1", features = ["std"] }
 embedded-io-adapters = { version = "0.7", features = ["std", "futures-03"] }
-async-io = "2"
+async-io-mini = "0.4"
 async-executor = "1"
 embassy-time = { version = "0.5", features = ["std", "generic-queue-64"] }
+edge-nal-std = { version = "0.6", features = ["async-io-mini"] }
+futures-lite = "1"
+
+[target.'cfg(not(target_os = "espidf"))'.dependencies]
+env_logger = "0.11"
+
+[target.'cfg(target_os = "espidf")'.dependencies]
+esp-idf-svc = "0.51"
 
 [build-dependencies]
 embuild = { version = "0.33", features = ["espidf"] }

--- a/examples/std/sdkconfig.defaults
+++ b/examples/std/sdkconfig.defaults
@@ -1,0 +1,6 @@
+# Examples often require a larger than the default stack size for the main thread and for the sysloop event task.
+# Necessary when the `embassy-time-driver` feature is enabled
+CONFIG_ESP_TIMER_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=20000
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=8192
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=8192

--- a/examples/std/src/bin/blocking_client.rs
+++ b/examples/std/src/bin/blocking_client.rs
@@ -11,13 +11,15 @@ use esp_mbedtls::Tls;
 
 use log::info;
 
+#[path = "../bootstrap.rs"]
+mod bootstrap;
 #[path = "../../../common/blocking_client.rs"]
 mod client;
 #[path = "../../../common/std_rng.rs"]
 mod rng;
 
 fn main() {
-    env_logger::init();
+    bootstrap::bootstrap();
 
     info!("Initializing TLS");
 

--- a/examples/std/src/bin/blocking_server.rs
+++ b/examples/std/src/bin/blocking_server.rs
@@ -19,13 +19,15 @@ use esp_mbedtls::Tls;
 
 use log::{info, warn};
 
+#[path = "../bootstrap.rs"]
+mod bootstrap;
 #[path = "../../../common/std_rng.rs"]
 mod rng;
 #[path = "../../../common/blocking_server.rs"]
 mod server;
 
 fn main() {
-    env_logger::init();
+    bootstrap::bootstrap();
 
     info!("Initializing TLS");
 

--- a/examples/std/src/bin/crypto_self_test.rs
+++ b/examples/std/src/bin/crypto_self_test.rs
@@ -7,14 +7,17 @@ use esp_mbedtls::sys::self_test::MbedtlsSelfTest;
 use log::{error, info};
 
 fn main() {
+    #[cfg(not(target_os = "espidf"))]
     env_logger::init();
+    #[cfg(target_os = "espidf")]
+    esp_idf_svc::log::EspLogger::initialize_default();
 
     info!("Running MbedTLS self tests...");
 
     info!("TESTS OUTPUT >>>>>>>>");
 
     for mut test in enumset::EnumSet::<MbedtlsSelfTest>::all() {
-        println!("Testing {:?}", test);
+        info!("Testing {:?}", test);
 
         let before = Instant::now();
 
@@ -22,7 +25,7 @@ fn main() {
             error!("Self-test {:?} failed!", test);
         }
 
-        println!("Took {:?}", before.elapsed());
+        info!("Took {:?}", before.elapsed());
     }
 
     info!("<<<<<<<< TESTS OUTPUT");

--- a/examples/std/src/bin/server.rs
+++ b/examples/std/src/bin/server.rs
@@ -14,7 +14,7 @@ use std::net::TcpListener;
 
 use async_executor::LocalExecutor;
 
-use async_io::Async;
+use async_io_mini::Async;
 
 use embedded_io_adapters::futures_03::FromFutures;
 
@@ -22,15 +22,17 @@ use esp_mbedtls::Tls;
 
 use log::{info, warn};
 
+#[path = "../bootstrap.rs"]
+mod bootstrap;
 #[path = "../../../common/std_rng.rs"]
 mod rng;
 #[path = "../../../common/server.rs"]
 mod server;
 
 fn main() {
-    env_logger::init();
+    bootstrap::bootstrap();
 
-    async_io::block_on(run());
+    bootstrap::block_on(run());
 }
 
 async fn run() {
@@ -64,7 +66,7 @@ async fn accept<'a>(executor: &LocalExecutor<'a>, tls: &'a Tls<'_>) {
 
         executor
             .spawn(async move {
-                let mut buf = [0u8; 4096];
+                let mut buf = vec![0; 4096];
 
                 if let Err(e) = server::reply(tls, FromFutures::new(socket), false, &mut buf).await
                 {

--- a/examples/std/src/bootstrap.rs
+++ b/examples/std/src/bootstrap.rs
@@ -1,0 +1,73 @@
+#[cfg(not(target_os = "espidf"))]
+pub fn bootstrap() {
+    env_logger::init();
+}
+
+#[cfg(target_os = "espidf")]
+#[cold]
+#[inline(never)]
+pub fn bootstrap() {
+    use esp_idf_svc::eventloop::EspSystemEventLoop;
+    use esp_idf_svc::hal::peripherals::Peripherals;
+    use esp_idf_svc::io::vfs::MountedEventfs;
+    use esp_idf_svc::nvs::EspDefaultNvsPartition;
+    use esp_idf_svc::wifi::*;
+
+    use log::info;
+
+    const WIFI_SSID: &str = env!("WIFI_SSID");
+    const WIFI_PASS: &str = env!("WIFI_PASS");
+
+    esp_idf_svc::log::EspLogger::initialize_default();
+
+    let peripherals = Peripherals::take().unwrap();
+    let sys_loop = EspSystemEventLoop::take().unwrap();
+    let nvs = EspDefaultNvsPartition::take().unwrap();
+
+    let mut wifi = Box::new(
+        BlockingWifi::wrap(
+            EspWifi::new(peripherals.modem, sys_loop.clone(), Some(nvs)).unwrap(),
+            sys_loop,
+        )
+        .unwrap(),
+    );
+
+    let wifi_configuration: Configuration = Configuration::Client(ClientConfiguration {
+        auth_method: AuthMethod::WPA2Personal,
+        ssid: WIFI_SSID.try_into().unwrap(),
+        password: WIFI_PASS.try_into().unwrap(),
+        ..Default::default()
+    });
+
+    wifi.set_configuration(&wifi_configuration).unwrap();
+
+    wifi.start().unwrap();
+    info!("Wifi started");
+
+    wifi.connect().unwrap();
+    info!("Wifi connected");
+
+    wifi.wait_netif_up().unwrap();
+    info!("Wifi netif up");
+
+    let ip_info = wifi.wifi().sta_netif().get_ip_info().unwrap();
+
+    info!("Wifi DHCP info: {ip_info:?}");
+
+    // Keep the wifi driver active by not dropping it
+    core::mem::forget(wifi);
+
+    // Ditto for event_fs which is used by `async-io-mini`
+    let event_fs = MountedEventfs::mount(2).unwrap();
+    core::mem::forget(event_fs);
+}
+
+#[allow(unused)]
+pub fn block_on<F: core::future::Future>(fut: F) -> F::Output {
+    #[cfg(not(target_os = "espidf"))]
+    let res = futures_lite::future::block_on(fut);
+    #[cfg(target_os = "espidf")]
+    let res = esp_idf_svc::hal::task::block_on(fut);
+
+    res
+}


### PR DESCRIPTION
~~**(NOTE: This needs #99 to be merged first!**~~

Description:

This PR restores support for ESP-IDF.

### Changes to esp-mbedtls / esp-mbedtls-sys

The changes to `esp-mbedtls`/`esp-mbedtls-sys` are just fixing of several imports.

### Changes to the examples

The STD examples were slightly adjusted to work for ESP-IDF which is also a STD platform.

The major change is the introduction of a `bootstrap` module - similar to the one in the ESP baremetal examples - which takes care of ESP-IDF specifics like starting up ESP-IDF logging and connecting to Wifi.

### Changes to CI

CI was enhanced to work for two ESP-IDF targets. Building for all ESP-IDF targets would delay the CI too much, so only 2 are enabled for now.

### Misc

Some comments from @AnthonyGrondin - primarily w.r.t. logging level and cargo flash baudrate from #95 were incorporated here as well.