### PR TITLE
Run esp32 examples at max CPU speed.

### DIFF
--- a/examples/esp/src/bootstrap.rs
+++ b/examples/esp/src/bootstrap.rs
@@ -62,7 +62,8 @@ pub async fn bootstrap_stack<const SOCKETS: usize>(
 
     heap_allocator!(#[ram(reclaimed)] size: RECLAIMED_RAM);
 
-    let peripherals = esp_hal::init(esp_hal::Config::default());
+    let peripherals =
+        esp_hal::init(esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()));
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(


### PR DESCRIPTION
This fixes a regression where examples would run at slower speed than previously due to default config not running at max CPU speed.