### PR TITLE
Add suppor for session reuse

### DIFF
--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -18,9 +18,9 @@ use crate::sys::{
     mbedtls_ssl_config_free, mbedtls_ssl_config_init, mbedtls_ssl_context, mbedtls_ssl_free,
     mbedtls_ssl_init, mbedtls_ssl_protocol_version,
     mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_2,
-    mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_3, mbedtls_x509_crt,
-    mbedtls_x509_crt_free, mbedtls_x509_crt_init,
-    mbedtls_ssl_session, mbedtls_ssl_session_free, mbedtls_ssl_session_init,
+    mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_3, mbedtls_ssl_session,
+    mbedtls_ssl_session_free, mbedtls_ssl_session_init, mbedtls_x509_crt, mbedtls_x509_crt_free,
+    mbedtls_x509_crt_init,
 };
 
 use rand_core::CryptoRng;

--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -20,6 +20,7 @@ use crate::sys::{
     mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_2,
     mbedtls_ssl_protocol_version_MBEDTLS_SSL_VERSION_TLS1_3, mbedtls_x509_crt,
     mbedtls_x509_crt_free, mbedtls_x509_crt_init,
+    mbedtls_ssl_session, mbedtls_ssl_session_free, mbedtls_ssl_session_init,
 };
 
 use rand_core::CryptoRng;
@@ -228,6 +229,20 @@ impl MInit for mbedtls_ssl_config {
     fn deinit(&mut self) {
         unsafe {
             mbedtls_ssl_config_free(self);
+        }
+    }
+}
+
+impl MInit for mbedtls_ssl_session {
+    fn init(&mut self) {
+        unsafe {
+            mbedtls_ssl_session_init(self);
+        }
+    }
+
+    fn deinit(&mut self) {
+        unsafe {
+            mbedtls_ssl_session_free(self);
         }
     }
 }

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -11,7 +11,7 @@ mod asynch;
 pub mod blocking;
 
 /// A reusable TLS session state captured from a connected session.
-pub struct ReusedSession {
+pub struct SavedSession {
     pub(crate) mbedtls_session: MBox<mbedtls_ssl_session>,
 }
 
@@ -279,10 +279,6 @@ pub enum SessionError {
     MbedTls(MbedtlsError),
     /// IO error
     Io(ErrorKind),
-    /// Session is already connected
-    AlreadyConnected,
-    /// Session is not connected
-    NotConnected,
 }
 
 impl SessionError {
@@ -309,8 +305,6 @@ impl core::fmt::Display for SessionError {
         match self {
             Self::MbedTls(e) => write!(f, "{}", e),
             Self::Io(e) => write!(f, "IO({:?})", e),
-            Self::AlreadyConnected => write!(f, "Session already connected"),
-            Self::NotConnected => write!(f, "Session not connected"),
         }
     }
 }

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -10,6 +10,11 @@ pub use asynch::*;
 mod asynch;
 pub mod blocking;
 
+/// A reusable TLS session state captured from a connected session.
+pub struct ReusedSession {
+    pub(crate) mbedtls_session: MBox<mbedtls_ssl_session>,
+}
+
 /// Certificate verification mode used for a session
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -274,6 +279,10 @@ pub enum SessionError {
     MbedTls(MbedtlsError),
     /// IO error
     Io(ErrorKind),
+    /// Session is already connected
+    AlreadyConnected,
+    /// Session is not connected
+    NotConnected,
 }
 
 impl SessionError {
@@ -300,6 +309,8 @@ impl core::fmt::Display for SessionError {
         match self {
             Self::MbedTls(e) => write!(f, "{}", e),
             Self::Io(e) => write!(f, "IO({:?})", e),
+            Self::AlreadyConnected => write!(f, "Session already connected"),
+            Self::NotConnected => write!(f, "Session not connected"),
         }
     }
 }
@@ -310,6 +321,8 @@ impl defmt::Format for SessionError {
         match self {
             Self::MbedTls(e) => defmt::write!(f, "{}", e),
             Self::Io(e) => defmt::write!(f, "IO({:?})", debug2format!(e)),
+            Self::AlreadyConnected => defmt::write!(f, "Session already connected"),
+            Self::NotConnected => defmt::write!(f, "Session not connected"),
         }
     }
 }

--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -315,8 +315,6 @@ impl defmt::Format for SessionError {
         match self {
             Self::MbedTls(e) => defmt::write!(f, "{}", e),
             Self::Io(e) => defmt::write!(f, "IO({:?})", debug2format!(e)),
-            Self::AlreadyConnected => defmt::write!(f, "Session already connected"),
-            Self::NotConnected => defmt::write!(f, "Session not connected"),
         }
     }
 }

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -11,7 +11,7 @@ use crate::sys::MbedtlsError;
 use crate::sys::*;
 use crate::{SessionError, TlsReference};
 
-use super::{ReusedSession, SessionConfig, SessionState};
+use super::{SavedSession, SessionConfig, SessionState};
 
 /// Re-export of the `embedded-io-async` crate so that users don't have to explicitly depend on it
 /// to use e.g. `write_all` or `read_exact`.
@@ -106,18 +106,15 @@ where
         Ok(())
     }
 
-    /// Negotiate the TLS connection
-    ///
-    /// This function will perform the TLS handshake with the server.
-    ///
-    /// Note that calling it is not mandatory, because the TLS session is anyway
-    /// negotiated during the first read or write operation, or when splitting the session.
-    pub async fn connect(&mut self) -> Result<(), SessionError> {
+    async fn connect_internal(
+        &mut self,
+        saved_session: Option<&SavedSession>,
+    ) -> Result<(), SessionError> {
         if self.connected {
             return Ok(());
         }
 
-        MBio::from_session(self).connect().await?;
+        MBio::from_session(self).connect(saved_session).await?;
 
         self.connected = true;
         self.eof = false;
@@ -125,25 +122,24 @@ where
         Ok(())
     }
 
+    /// Negotiate the TLS connection
+    ///
+    /// This function will perform the TLS handshake with the server.
+    ///
+    /// Note that calling it is not mandatory, because the TLS session is anyway
+    /// negotiated during the first read or write operation, or when splitting the session.
+    pub async fn connect(&mut self) -> Result<(), SessionError> {
+        self.connect_internal(None).await
+    }
+
     /// Negotiate the TLS connection attempting to reuse a previously captured session.
-    pub async fn connect_reuse(
+    ///
+    /// Use [`Session::save`] to get a copy of the session to use here  
+    pub async fn connect_with_session(
         &mut self,
-        reused_session: &ReusedSession,
+        saved_session: &SavedSession,
     ) -> Result<(), SessionError> {
-        if self.connected {
-            return Err(SessionError::AlreadyConnected);
-        }
-
-        merr!(unsafe {
-            mbedtls_ssl_set_session(
-                // &mut *self.state.ssl_context,
-                self.state.ssl_context.0.as_mut(),
-                // &*reused_session.mbedtls_session,
-                reused_session.mbedtls_session.as_ref(),
-            )
-        })?;
-
-        self.connect().await
+        self.connect_internal(Some(saved_session)).await
     }
 
     /// Split the TLS session into read and write halves
@@ -249,23 +245,13 @@ where
     }
 
     /// Capture the negotiated MbedTLS session for possible reuse.
-    pub fn get_mbedtls_session(&self) -> Result<ReusedSession, SessionError> {
-        if !self.connected {
-            return Err(SessionError::NotConnected);
-        }
-
+    pub fn save(&self) -> Result<SavedSession, SessionError> {
         let mut mbedtls_session: super::super::MBox<mbedtls_ssl_session> =
             super::super::MBox::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?;
 
-        merr!(unsafe {
-            mbedtls_ssl_get_session(
-                &*self.state.ssl_context,
-                // &mut *mbedtls_session,
-                mbedtls_session.0.as_mut(),
-            )
-        })?;
+        merr!(unsafe { mbedtls_ssl_get_session(&*self.state.ssl_context, &mut *mbedtls_session) })?;
 
-        Ok(ReusedSession { mbedtls_session })
+        Ok(SavedSession { mbedtls_session })
     }
 }
 
@@ -565,10 +551,19 @@ where
     }
 
     /// Establish the SSL connection
-    async fn connect(&mut self) -> Result<(), SessionError> {
+    async fn connect(&mut self, saved_session: Option<&SavedSession>) -> Result<(), SessionError> {
         debug!("Establishing SSL connection");
 
         merr!(unsafe { mbedtls_ssl_session_reset(self.ssl_context as *const _ as *mut _) })?;
+
+        if let Some(saved_session) = saved_session {
+            merr!(unsafe {
+                mbedtls_ssl_set_session(
+                    self.ssl_context as *const _ as *mut _,
+                    &*saved_session.mbedtls_session,
+                )
+            })?;
+        }
 
         loop {
             match self

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -7,10 +7,11 @@ use embedded_io::ErrorKind;
 
 use io::{ErrorType, Read, Write};
 
+use crate::sys::MbedtlsError;
 use crate::sys::*;
 use crate::{SessionError, TlsReference};
 
-use super::{SessionConfig, SessionState};
+use super::{ReusedSession, SessionConfig, SessionState};
 
 /// Re-export of the `embedded-io-async` crate so that users don't have to explicitly depend on it
 /// to use e.g. `write_all` or `read_exact`.
@@ -124,6 +125,27 @@ where
         Ok(())
     }
 
+    /// Negotiate the TLS connection attempting to reuse a previously captured session.
+    pub async fn connect_reuse(
+        &mut self,
+        reused_session: &ReusedSession,
+    ) -> Result<(), SessionError> {
+        if self.connected {
+            return Err(SessionError::AlreadyConnected);
+        }
+
+        let res = merr!(unsafe {
+            mbedtls_ssl_set_session(
+                // &mut *self.state.ssl_context,
+                self.state.ssl_context.0.as_mut(),
+                // &*reused_session.mbedtls_session,
+                reused_session.mbedtls_session.as_ref()
+            )
+        })?;
+
+        self.connect().await
+    }
+
     /// Split the TLS session into read and write halves
     ///
     /// # Returns
@@ -224,6 +246,26 @@ where
         self.connected = false;
 
         Ok(())
+    }
+
+    /// Capture the negotiated MbedTLS session for possible reuse.
+    pub fn get_mbedtls_session(&self) -> Result<ReusedSession, SessionError> {
+        if !self.connected {
+            return Err(SessionError::NotConnected);
+        }
+
+        let mut mbedtls_session : super::super::MBox<mbedtls_ssl_session> =
+            super::super::MBox::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?;
+
+        merr!(unsafe {
+            mbedtls_ssl_get_session(
+                &*self.state.ssl_context,
+                // &mut *mbedtls_session,
+                mbedtls_session.0.as_mut()
+            )
+        })?;
+
+        Ok(ReusedSession { mbedtls_session })
     }
 }
 

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -139,7 +139,7 @@ where
                 // &mut *self.state.ssl_context,
                 self.state.ssl_context.0.as_mut(),
                 // &*reused_session.mbedtls_session,
-                reused_session.mbedtls_session.as_ref()
+                reused_session.mbedtls_session.as_ref(),
             )
         })?;
 
@@ -254,14 +254,14 @@ where
             return Err(SessionError::NotConnected);
         }
 
-        let mut mbedtls_session : super::super::MBox<mbedtls_ssl_session> =
+        let mut mbedtls_session: super::super::MBox<mbedtls_ssl_session> =
             super::super::MBox::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?;
 
         merr!(unsafe {
             mbedtls_ssl_get_session(
                 &*self.state.ssl_context,
                 // &mut *mbedtls_session,
-                mbedtls_session.0.as_mut()
+                mbedtls_session.0.as_mut(),
             )
         })?;
 

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -134,7 +134,7 @@ where
             return Err(SessionError::AlreadyConnected);
         }
 
-        let res = merr!(unsafe {
+        merr!(unsafe {
             mbedtls_ssl_set_session(
                 // &mut *self.state.ssl_context,
                 self.state.ssl_context.0.as_mut(),

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -7,7 +7,6 @@ use embedded_io::ErrorKind;
 
 use io::{ErrorType, Read, Write};
 
-use crate::sys::MbedtlsError;
 use crate::sys::*;
 use crate::{SessionError, TlsReference};
 

--- a/mbedtls-rs/src/session/blocking.rs
+++ b/mbedtls-rs/src/session/blocking.rs
@@ -4,7 +4,7 @@ use io::{ErrorType, Read, Write};
 
 use crate::sys::*;
 
-use super::{SessionConfig, SessionError, SessionState, TlsReference};
+use super::{SavedSession, SessionConfig, SessionError, SessionState, TlsReference};
 
 /// Re-export of the `embedded-io` crate so that users don't have to explicitly depend on it
 /// to use e.g. `write_all` or `read_exact`.
@@ -73,18 +73,24 @@ where
         Ok(())
     }
 
-    /// Negotiate the TLS connection
-    ///
-    /// This function will perform the TLS handshake with the server.
-    ///
-    /// Note that calling it is not mandatory, because the TLS session is anyway
-    /// negotiated during the first read or write operation.
-    pub fn connect(&mut self) -> Result<(), SessionError> {
+    fn connect_internal(
+        &mut self,
+        saved_session: Option<&SavedSession>,
+    ) -> Result<(), SessionError> {
         if self.connected {
             return Ok(());
         }
 
         merr!(unsafe { mbedtls_ssl_session_reset(&mut *self.state.ssl_context) })?;
+
+        if let Some(saved_session) = saved_session {
+            merr!(unsafe {
+                mbedtls_ssl_set_session(
+                    &*self.state.ssl_context as *const _ as *mut _,
+                    &*saved_session.mbedtls_session,
+                )
+            })?;
+        }
 
         loop {
             match self.call_mbedtls(|ssl_ctx| unsafe { mbedtls_ssl_handshake(ssl_ctx) }) {
@@ -102,6 +108,26 @@ where
                 }
             }
         }
+    }
+
+    /// Negotiate the TLS connection
+    ///
+    /// This function will perform the TLS handshake with the server.
+    ///
+    /// Note that calling it is not mandatory, because the TLS session is anyway
+    /// negotiated during the first read or write operation.
+    pub fn connect(&mut self) -> Result<(), SessionError> {
+        self.connect_internal(None)
+    }
+
+    /// Negotiate the TLS connection attempting to reuse a previously captured session.
+    ///
+    /// Use [`Session::save`] to get a copy of the session to use here  
+    pub fn connect_with_session(
+        &mut self,
+        saved_session: &SavedSession,
+    ) -> Result<(), SessionError> {
+        self.connect_internal(Some(saved_session))
     }
 
     /// Get the TLS verification details
@@ -285,6 +311,16 @@ where
         let session = (ctx as *mut Self).as_mut().unwrap();
 
         session.bio_send(core::slice::from_raw_parts(buf as *const _, len))
+    }
+
+    /// Capture the negotiated MbedTLS session for possible reuse.
+    pub fn save(&self) -> Result<SavedSession, SessionError> {
+        let mut mbedtls_session: super::super::MBox<mbedtls_ssl_session> =
+            super::super::MBox::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?;
+
+        merr!(unsafe { mbedtls_ssl_get_session(&*self.state.ssl_context, &mut *mbedtls_session) })?;
+
+        Ok(SavedSession { mbedtls_session })
     }
 }
 


### PR DESCRIPTION
I added session reuse - it is required for certain ftp servers that won't work without it, will reject.
Initially it didn't work and I couldn't figure out why. Five minutes after submitting this PR asking for help I found the root cause.

The code I added is code that worked on a previous version of esp-mbedtls right when esp-hal 1.0.0 came out (I used PR96), adapted to the new conventions introduced since then.

The change in the new version that prevents this from working, is that `connect()` begins with :

```rust
    /// Establish the SSL connection
    async fn connect(&mut self) -> Result<(), SessionError> {
        debug!("Establishing SSL connection");

     merr!(unsafe { mbedtls_ssl_session_reset(self.ssl_context as *const _ as *mut _) })?;

```

`mbedtls_ssl_session_reset` resets the context right after my connect_reuse fills in the session to reuse in the context, so obviously it can't reuse the session.

I remarked this line in my code and it is now working, including the connect that isn't reused.

1. is session_reset required at the beginning of connect? in previous version it was called only in case of certain errors:

```rust
            loop {
                let res = mbedtls_ssl_handshake(self.ssl_context);
                log::debug!("mbedtls_ssl_handshake: {res:x}");
                if res == 0 {
                    // success
                    break;
                }
                if res < 0 && res != MBEDTLS_ERR_SSL_WANT_READ && res != MBEDTLS_ERR_SSL_WANT_WRITE
                    // See https://github.com/Mbed-TLS/mbedtls/issues/8749
                    && res != MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET
                {
                    // real error
                    // Reference: https://os.mbed.com/teams/sandbox/code/mbedtls/docs/tip/ssl_8h.html#a4a37e497cd08c896870a42b1b618186e
                    mbedtls_ssl_session_reset(self.ssl_context);
                    #[allow(non_snake_case)]
                    return Err(match res {
                        MBEDTLS_ERR_SSL_NO_CLIENT_CERTIFICATE => TlsError::NoClientCertificate,
                        _ => TlsError::MbedTlsError(res),
                    });
                }

                // try again immediately
            }

```

2. If it is required, how would you recommend I solve this?