### PR TITLE
Update esp-hal to 1.1.0-rc.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions: read-all
+
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.
 #
@@ -44,13 +46,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    permissions: read-all
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: mbedtls init
-        run: git submodule update --init --recursive
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@v1
         with:
@@ -58,24 +58,26 @@ jobs:
           toolchain: stable
           components: rust-src,rustfmt
 
-      # TODO: Double-check and uncomment
-      # - uses: Swatinem/rust-cache@v2
-      #   with:
-      #     workspaces: |
-      #       ./
-      #       xtask
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            examples/std -> examples/std/target
 
       - name: Fmt Check
-        run: cargo fmt -- --check
+        run: |
+          cargo fmt -- --check
+          cargo fmt --manifest-path examples/std/Cargo.toml -- --check
+          cargo fmt --manifest-path examples/esp/Cargo.toml -- --check
 
       - name: Clippy
         run: cargo clippy -- -D warnings
 
-      - name: Build
+      - name: Build - Clang
         run: cargo build
 
-      - name: Fmt Check - STD Examples
-        run: cd examples/std; cargo fmt -- --check
+      - name: Build - GCC
+        run: cargo build -p mbedtls-rs --features use-gcc
 
       - name: Clippy - STD Examples
         run: cd examples/std; cargo clippy -- -D warnings
@@ -86,71 +88,60 @@ jobs:
   build-mbedtls:
     name: Build MbedTLS
     runs-on: ubuntu-latest
-    permissions: read-all
-    needs: build
     outputs:
       upload-libs: ${{ steps.detect-changes.outputs.libs == 'true' }}
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: mbedtls init
-        run: git submodule update --init --recursive
-
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          target: x86_64-unknown-linux-gnu
-          toolchain: nightly
-          components: rust-src,rustfmt
-
-      # TODO: Double-check and uncomment
-      # - uses: Swatinem/rust-cache@v2
-      #   with:
-      #     workspaces: |
-      #       ./
-      #       xtask
+      - uses: actions/checkout@v6
 
       - name: Detect mbedtls-rs-sys/ changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: detect-changes
         with:
           filters: |
             libs:
               - 'mbedtls-rs-sys/**'
 
-      - name: Detect host target triple
-        run: |
-          export HOST_TARGET=$(rustup show | grep "Default host" | sed -e 's/.* //')
-          echo "HOST_TARGET=$HOST_TARGET" >> $GITHUB_ENV
+      - name: mbedtls init
+        if: |
+          steps.detect-changes.outputs.libs == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
+        run: git submodule update --init --recursive
 
-      - name: Install espup
-        run: |
-          curl -LO https://github.com/esp-rs/espup/releases/latest/download/espup-${{ env.HOST_TARGET }}.zip
-          unzip -o espup-${{ env.HOST_TARGET }}.zip -d "$HOME/.cargo/bin"
-          chmod +x "$HOME/.cargo/bin/espup"*
-          echo "ESPUP_EXPORT_FILE=$HOME/exports" >> $GITHUB_ENV
+      - uses: dtolnay/rust-toolchain@v1
+        if: |
+          steps.detect-changes.outputs.libs == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
+        with:
+          target: x86_64-unknown-linux-gnu
+          toolchain: nightly
+          components: rust-src,rustfmt
 
-      - name: Install espup toolchains (xtensa and riscv)
-        run: |
-          source "$HOME/.cargo/env"
-          "$HOME/.cargo/bin/espup" install -e -r
-          source "$HOME/exports"
-          echo "${LIBCLANG_PATH}/../bin:$PATH" >> "$GITHUB_PATH"
-          echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
-          echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        if: |
+          steps.detect-changes.outputs.libs == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
+        with:
+          workspaces: |
+            . -> target
+            xtask -> xtask/target
 
-# TODO: Remove the manual espup installation and run once the action below
-# supports the `-r` flag to install the Espressif RISCV GCC toolchain
-# See https://github.com/esp-rs/xtensa-toolchain/issues/45 for more info
-#      - name: Install Rust for Xtensa and Espressif LLVM installation (optional)
-#        uses: esp-rs/xtensa-toolchain@v1.6
-#        with:
-#          ldproxy: true
-#          override: false
-#          extended-llvm: ${{
-#            steps.detect-changes.outputs.libs == 'true' ||
-#            contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
-#            }}
+      - name: Install Rust for Xtensa and Espressif LLVM installation (optional)
+        if: |
+          steps.detect-changes.outputs.libs == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
+        uses: esp-rs/xtensa-toolchain@v1.7
+        with:
+          ldproxy: true
+          override: false
+          extended-llvm: ${{
+            steps.detect-changes.outputs.libs == 'true' ||
+            contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
+            }}
+          esp-riscv-gcc: ${{
+            steps.detect-changes.outputs.libs == 'true' ||
+            contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
+            }}
 
       - name: Build MbedTLS libraries and bindings
         if: |
@@ -169,10 +160,11 @@ jobs:
           (steps.detect-changes.outputs.libs == 'true' &&
           github.ref == 'refs/heads/main') ||
           contains(github.event.pull_request.labels.*.name, 'rebuild-libs')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mbedtls-rs-sys
           retention-days: 1
+          if-no-files-found: error
           path: |
             mbedtls-rs-sys/libs
             mbedtls-rs-sys/src/include
@@ -180,8 +172,7 @@ jobs:
   build-mcu:
     name: Build-MCU
     runs-on: ubuntu-latest
-    permissions: read-all
-    needs: build-mbedtls
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -195,64 +186,40 @@ jobs:
 # No Wifi support on esp32h2
 #          - [esp, esp32h2, riscv32imac-unknown-none-elf]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
           toolchain: nightly
-          components: rust-src,rustfmt,clippy
+          components: rust-src,clippy
 
       - name: Install MCU target
         if: startsWith(matrix.mcu[2], 'riscv32')
         run: rustup target add ${{ matrix.mcu[2] }}
 
-      - name: Install Rust for Xtensa
-        if: startsWith(matrix.mcu[2], 'xtensa-')
-        uses: esp-rs/xtensa-toolchain@v1.6
+      - name: Install Espressif toolchains
+        uses: esp-rs/xtensa-toolchain@v1.7
         with:
-          default: true
+          default: ${{ startsWith(matrix.mcu[2], 'xtensa-') }}
           ldproxy: true
+          override: false
+          extended-llvm: true
+          esp-riscv-gcc: true
 
-      # TODO: Double-check and uncomment
-      # - uses: Swatinem/rust-cache@v2
-      #   with:
-      #     workspaces: |
-      #       ./
-      #       xtask
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            examples/esp -> examples/esp/target
 
       - name: Clippy
         run: cargo clippy --features ${{ matrix.mcu[1] }} --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort -- -D warnings
 
-      - name: Build
+      - name: Build - Clang
         run: cargo build --features ${{ matrix.mcu[1] }} --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort
-
-      - name: Fmt Check - Examples
-        run: cd examples/${{ matrix.mcu[0] }}; cargo fmt -- --check
-
-      - name: mbedtls init
-        run: git submodule update --init --recursive
-
-      - name: Detect host target triple
-        run: |
-          export HOST_TARGET=$(rustup show | grep "Default host" | sed -e 's/.* //')
-          echo "HOST_TARGET=$HOST_TARGET" >> $GITHUB_ENV
-
-      - name: Install espup
-        run: |
-          curl -LO https://github.com/esp-rs/espup/releases/latest/download/espup-${{ env.HOST_TARGET }}.zip
-          unzip -o espup-${{ env.HOST_TARGET }}.zip -d "$HOME/.cargo/bin"
-          chmod +x "$HOME/.cargo/bin/espup"*
-          echo "ESPUP_EXPORT_FILE=$HOME/exports" >> $GITHUB_ENV
-
-      - name: Install espup toolchains (xtensa and riscv)
-        run: |
-          source "$HOME/.cargo/env"
-          "$HOME/.cargo/bin/espup" install -e -r
-          source "$HOME/exports"
-          echo "${LIBCLANG_PATH}/../bin:$PATH" >> "$GITHUB_PATH"
-          echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
-          echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
 
       - name: Clippy - Examples
         run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo clippy --no-default-features --features ${{ matrix.mcu[1] }} --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort -- -D warnings
@@ -260,11 +227,16 @@ jobs:
       - name: Build - Examples
         run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo build --no-default-features --features ${{ matrix.mcu[1] }} --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort
 
+      # `force-esp-riscv-gcc` implies `use-gcc`; its RISC-V compiler override
+      # only affects RISC-V targets, so it is safe to use for the Xtensa check too.
+      - name: Build - Examples - GCC
+        if: matrix.mcu[1] == 'esp32s3' || matrix.mcu[1] == 'esp32c6'
+        run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo build --no-default-features --features ${{ matrix.mcu[1] }},mbedtls-rs/force-esp-riscv-gcc,mbedtls-rs/force-generate-bindings --target ${{ matrix.mcu[2] }} -Zbuild-std=core,alloc,panic_abort
+
   build-esp-idf:
     name: Build-ESP-IDF
     runs-on: ubuntu-latest
-    permissions: read-all
-    needs: build-mcu
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -278,13 +250,13 @@ jobs:
 # No Wifi support on esp32h2
 #          - [std, esp32h2, riscv32imac-esp-espidf]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: x86_64-unknown-linux-gnu
           toolchain: nightly
-          components: rust-src,rustfmt,clippy
+          components: rust-src,clippy
 
       - name: Install MCU target
         if: startsWith(matrix.mcu[2], 'riscv32')
@@ -292,26 +264,22 @@ jobs:
 
       - name: Install Rust for Xtensa
         if: startsWith(matrix.mcu[2], 'xtensa-')
-        uses: esp-rs/xtensa-toolchain@v1.6
+        uses: esp-rs/xtensa-toolchain@v1.7
         with:
           default: true
           ldproxy: true
 
-      # TODO: Double-check and uncomment
-      # - uses: Swatinem/rust-cache@v2
-      #   with:
-      #     workspaces: |
-      #       ./
-      #       xtask
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            examples/std -> examples/std/target
 
       - name: Clippy
         run: cargo clippy --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort -- -D warnings
 
-      - name: Build
+      - name: Build - Clang
         run: cargo build --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort
-
-      - name: Fmt Check - Examples
-        run: cd examples/${{ matrix.mcu[0] }}; cargo fmt -- --check
 
       - name: Clippy - Examples
         run: export WIFI_SSID=ssid; export WIFI_PASS=pass; cd examples/${{ matrix.mcu[0] }}; cargo clippy --target ${{ matrix.mcu[2] }} -Zbuild-std=std,panic_abort -- -D warnings
@@ -326,7 +294,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: build-esp-idf
+    needs:
+      - build-mbedtls
+      - build-mcu
+      - build-esp-idf
     # TODO: Currently GitHub doesn't allow pushing to a forked repo's branch when running an action on a PR to upstream.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -334,7 +305,7 @@ jobs:
       github.ref == 'refs/heads/main') ||
       contains(github.event.pull_request.labels.*.name, 'rebuild-libs'))
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # In a pull request trigger, ref is required as GitHub Actions checks out in detached HEAD mode,
           # meaning it doesn’t check out your branch by default.
@@ -343,7 +314,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mbedtls-rs-sys
           # Required because else artifacts will be put into the base directory

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,7 @@ members = [
 exclude = ["examples", "xtask"]
 
 [patch.crates-io]
-esp-hal = { git = "https://github.com/esp-rs/esp-hal" }
+# Patch until https://github.com/sysgrok/edge-net/commit/1f084b41944c35b233cbe17accfbc09a56d5eaf0 is released
+edge-nal = { git = "https://github.com/sysgrok/edge-net", rev = "1f084b4" }
+edge-nal-embassy = { git = "https://github.com/sysgrok/edge-net", rev = "1f084b4" }
+edge-http = { git = "https://github.com/sysgrok/edge-net", rev = "1f084b4" }

--- a/examples/common/std_rng.rs
+++ b/examples/common/std_rng.rs
@@ -1,20 +1,25 @@
-use rand::{CryptoRng, RngCore};
+use core::convert::Infallible;
+
+use rand::{Rng, TryCryptoRng, TryRng};
 
 /// A standard, crypto-compliant random number generator using the `rand` crate which is `Send`.
 pub struct StdRng;
 
-impl RngCore for StdRng {
-    fn next_u32(&mut self) -> u32 {
-        rand::rng().next_u32()
+impl TryRng for StdRng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(rand::rng().next_u32())
     }
 
-    fn next_u64(&mut self) -> u64 {
-        rand::rng().next_u64()
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(rand::rng().next_u64())
     }
 
-    fn fill_bytes(&mut self, dst: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
         rand::rng().fill_bytes(dst);
+        Ok(())
     }
 }
 
-impl CryptoRng for StdRng {}
+impl TryCryptoRng for StdRng {}

--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -6,16 +6,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.84"
 
-[patch.crates-io]
-esp-rtos = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-alloc = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-radio = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-metadata-generated = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-
  # For some reason, opt-level "z" or "s" results in a much smaller HW accel
 [profile.release.package.esp-hal]
 opt-level = 3
@@ -48,25 +38,30 @@ critical-section = "1"
 heapless = "0.9"
 static_cell = "2"
 enumset = { version = "1", default-features = false }
-rand_core = "0.9"
+rand_core = "0.10.1"
 mbedtls-rs = { path = "../../mbedtls-rs", features = ["log", "hook-wall-clock"] }
 sha1 = { version = "0.10", default-features = false }
 tinyrlibc = { version = "0.5", default-features = false, features = ["memchr"] }
 
 embassy-time = "0.5"
-embassy-executor = "0.9"
-embassy-net = "0.8"
+embassy-executor = "0.10"
+embassy-net = "0.9"
 
 # For the `edge_*` examples
 edge-http = { version = "0.7", features = ["io"] }
 edge-nal-embassy = "0.8"
 
-esp-rtos = { version = "0.2", features = ["esp-radio", "embassy"] }
-esp-hal = { version = "1", features = ["log-04", "unstable", "exception-handler"] }
-esp-alloc = { version = "0.9" }
-esp-backtrace = { version = "0.18.1", features = ["panic-handler", "println"] }
-esp-println = { version = "0.16", optional = true, features = ["log-04"] }
-esp-radio = { version = "0.17", features = ["wifi", "log-04", "unstable"] }
-esp-bootloader-esp-idf = { version = "0.4", features = ["log-04"] }
-esp-metadata-generated = "0.3"
-#esp-rom-sys = "0.1"
+esp-rtos = { version = "0.3", features = ["esp-radio", "embassy"] }
+esp-hal = { version = "1.1.0-rc.0", features = ["log-04", "unstable", "exception-handler"] }
+esp-alloc = { version = "0.10" }
+esp-backtrace = { version = "0.19.0", features = ["panic-handler", "println"] }
+esp-println = { version = "0.17", optional = true, features = ["log-04"] }
+esp-radio = { version = "0.18", features = ["wifi", "log-04", "unstable"] }
+esp-bootloader-esp-idf = { version = "0.5", features = ["log-04"] }
+esp-metadata-generated = "0.4"
+
+[patch.crates-io]
+# Patch until https://github.com/sysgrok/edge-net/commit/1f084b41944c35b233cbe17accfbc09a56d5eaf0 is released
+edge-nal = { git = "https://github.com/sysgrok/edge-net", rev = "1f084b4" }
+edge-nal-embassy = { git = "https://github.com/sysgrok/edge-net", rev = "1f084b4" }
+edge-http = { git = "https://github.com/sysgrok/edge-net", rev = "1f084b4" }

--- a/examples/esp/src/bin/server.rs
+++ b/examples/esp/src/bin/server.rs
@@ -51,8 +51,8 @@ async fn main(spawner: Spawner) {
 
     let tls = mk_static!(Tls, tls);
 
-    spawner.spawn(http_task("Task 1", tls, stack)).ok();
-    spawner.spawn(http_task("Task 2", tls, stack)).ok();
+    spawner.spawn(http_task("Task 1", tls, stack).unwrap());
+    spawner.spawn(http_task("Task 2", tls, stack).unwrap());
 
     // Don't exit so that the acceleration routines can stay registered
     core::future::pending::<()>().await

--- a/examples/esp/src/bootstrap.rs
+++ b/examples/esp/src/bootstrap.rs
@@ -27,12 +27,12 @@ use esp_metadata_generated::memory_range;
 use esp_radio as _;
 use esp_radio::wifi::scan::ScanConfig;
 use esp_radio::wifi::sta::StationConfig;
-use esp_radio::wifi::ModeConfig;
+use esp_radio::wifi::Config;
+use esp_radio::wifi::ControllerConfig;
+use esp_radio::wifi::Interface;
 use esp_radio::wifi::WifiController;
-use esp_radio::wifi::WifiDevice;
-use esp_radio::wifi::WifiEvent;
 
-use log::info;
+use log::{error, info};
 
 extern crate alloc;
 
@@ -117,9 +117,20 @@ pub async fn bootstrap_stack<const SOCKETS: usize>(
 
     let trng = mk_static!(Trng, Trng::try_new().unwrap());
 
+    let station_config = Config::Station(
+        StationConfig::default()
+            .with_ssid(WIFI_SSID)
+            .with_password(WIFI_PASS.into()),
+    );
+
     // Configure and start the Wifi first
-    let (controller, wifi_interfaces) =
-        esp_radio::wifi::new(peripherals.WIFI, esp_radio::wifi::Config::default()).unwrap();
+    info!("Starting wifi");
+    let (mut controller, wifi_interfaces) = esp_radio::wifi::new(
+        peripherals.WIFI,
+        ControllerConfig::default().with_initial_config(station_config),
+    )
+    .unwrap();
+    info!("Wifi configured and started!");
     let config = embassy_net::Config::dhcpv4(Default::default());
 
     let seed = (trng.random() as u64) << 32 | trng.random() as u64;
@@ -127,8 +138,15 @@ pub async fn bootstrap_stack<const SOCKETS: usize>(
     // Init network stack
     let (stack, runner) = embassy_net::new(wifi_interfaces.station, config, stack_resources, seed);
 
-    spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(runner)).ok();
+    info!("Scan");
+    let scan_config = ScanConfig::default().with_max(10);
+    let result = controller.scan_async(&scan_config).await.unwrap();
+    for ap in result {
+        info!("{:?}", ap);
+    }
+
+    spawner.spawn(connection(controller).unwrap());
+    spawner.spawn(net_task(runner).unwrap());
 
     wait_ip(stack).await;
 
@@ -155,52 +173,29 @@ async fn wait_ip(stack: Stack<'_>) {
 
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
-    info!("Start connection task");
-    info!("Device capabilities: {:?}", controller.capabilities());
+    info!("start connection task");
 
     loop {
-        if matches!(controller.is_connected(), Ok(true)) {
-            // wait until we're no longer connected
-            controller
-                .wait_for_event(WifiEvent::StationDisconnected)
-                .await;
-            Timer::after(Duration::from_millis(5000)).await
-        }
-
-        if !matches!(controller.is_started(), Ok(true)) {
-            let station_config = ModeConfig::Station(
-                StationConfig::default()
-                    .with_ssid(WIFI_SSID.into())
-                    .with_password(WIFI_PASS.into()),
-            );
-            controller.set_config(&station_config).unwrap();
-            info!("Starting wifi");
-            controller.start_async().await.unwrap();
-            info!("Wifi started!");
-
-            info!("Scan");
-            let scan_config = ScanConfig::default().with_max(10);
-            let result = controller
-                .scan_with_config_async(scan_config)
-                .await
-                .unwrap();
-            for ap in result {
-                info!("{:?}", ap);
-            }
-        }
         info!("About to connect...");
 
         match controller.connect_async().await {
-            Ok(_) => info!("Wifi connected!"),
+            Ok(info) => {
+                info!("Wifi connected to {:?}", info);
+
+                // wait until we're no longer connected
+                let info = controller.wait_for_disconnect_async().await.ok();
+                error!("Disconnected: {:?}", info);
+            }
             Err(e) => {
-                info!("Failed to connect to wifi: {e:?}");
-                Timer::after(Duration::from_millis(5000)).await
+                error!("Failed to connect to wifi: {e:?}");
             }
         }
+
+        Timer::after(Duration::from_millis(5000)).await
     }
 }
 
 #[embassy_executor::task]
-async fn net_task(mut runner: Runner<'static, WifiDevice<'static>>) {
+async fn net_task(mut runner: Runner<'static, Interface<'static>>) {
     runner.run().await
 }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -23,7 +23,7 @@ enumset = { version = "1", default-features = false }
 edge-http = { version = "0.7", features = ["io"] }
 
 # STD-only dependencies
-rand = "0.9"
+rand = "0.10"
 critical-section = { version = "1", features = ["std"] }
 embedded-io-adapters = { version = "0.7", features = ["std", "futures-03"] }
 async-io-mini = "0.4"

--- a/mbedtls-rs-sys/Cargo.toml
+++ b/mbedtls-rs-sys/Cargo.toml
@@ -55,7 +55,7 @@ time = { version = "0.3", default-features = false, optional = true }
 critical-section = "1"
 
 # For esp-hal hook impls
-esp-hal = { version = "1", features = ["unstable"], optional = true }
+esp-hal = { version = "1.1.0-rc.0", features = ["unstable"], optional = true }
 crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"], optional = true }
 
 # For embassy timer hook impl

--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -239,7 +239,10 @@ impl MbedtlsBuilder {
         }
 
         if self.hooks.contains(Hook::Timer) {
-            builder = builder.allowlist_item("time_t");
+            builder = builder
+                .allowlist_item("time_t")
+                .allowlist_item("__int_least64_t")
+                .allowlist_item("__int64_t");
         }
 
         if self.hooks.contains(Hook::WallClock) {

--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -564,7 +564,13 @@ impl CMakeConfigurer {
 
     fn derive_forced_c_compiler(&self) -> Option<(PathBuf, bool)> {
         if self.force_clang {
-            Some((PathBuf::from("clang"), false))
+            Some((
+                std::env::var_os("CLANG_PATH")
+                    .filter(|path| !path.is_empty())
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("clang")),
+                false,
+            ))
         } else {
             match self.target().as_str() {
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => {

--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -50,6 +50,6 @@ log = { version = "0.4", default-features = false, optional = true }
 embedded-io = { version = "0.7" }
 embedded-io-async = { version = "0.7" }
 enumset = { version = "1", default-features = false }
-rand_core = "0.9"
+rand_core = "0.10.1"
 critical-section = "1"
 edge-nal = { version = "0.6", optional = true }


### PR DESCRIPTION
**chore: Update esp-hal to 1.1.0-rc.0**
- Bump `esp-hal` and related dependencies
  - Updated esp examples to reflect changes in APIs
- Bump `embassy-net` and `embassy-executor`
- Bump `rand` and `rand_core` to v10
- Reworked MbedTLS Builder to prioritize `CLANG_PATH` over `clang`.
 
**ci: Update toolchains and build coverage**
- Update actions to their latest versions, and use Node 24 instead of deprecated Node 20
- Use esp-rs/xtensa-toolchain instead of manual espup installation
- Enable CI caching for Rust workspaces
- Add GCC build coverage for host, Xtensa, and RISC-V
- Reduce duplicated workflow setup and allow independent jobs to run in parallel
- Fixes GCC compilation when timer hook is enabled.

Status: WIP because I still need to figure out issues with speed, binary size, and edge-server example doesn't respond to requests.

Fix #123 