### PR TITLE
Update esp-hal to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 ]
 
 exclude = ["examples", "xtask"]
-
-[patch.crates-io]
-esp-hal = { git = "https://github.com/esp-rs/esp-hal" }

--- a/examples/common/std_rng.rs
+++ b/examples/common/std_rng.rs
@@ -1,20 +1,25 @@
-use rand::{CryptoRng, RngCore};
+use core::convert::Infallible;
+
+use rand::{Rng, TryCryptoRng, TryRng};
 
 /// A standard, crypto-compliant random number generator using the `rand` crate which is `Send`.
 pub struct StdRng;
 
-impl RngCore for StdRng {
-    fn next_u32(&mut self) -> u32 {
-        rand::rng().next_u32()
+impl TryRng for StdRng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(rand::rng().next_u32())
     }
 
-    fn next_u64(&mut self) -> u64 {
-        rand::rng().next_u64()
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(rand::rng().next_u64())
     }
 
-    fn fill_bytes(&mut self, dst: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
         rand::rng().fill_bytes(dst);
+        Ok(())
     }
 }
 
-impl CryptoRng for StdRng {}
+impl TryCryptoRng for StdRng {}

--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -6,16 +6,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.84"
 
-[patch.crates-io]
-esp-rtos = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-alloc = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-radio = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-esp-metadata-generated = { git = "https://github.com/esp-rs/esp-hal", rev="8a9fd5e" }
-
  # For some reason, opt-level "z" or "s" results in a much smaller HW accel
 [profile.release.package.esp-hal]
 opt-level = 3
@@ -48,25 +38,24 @@ critical-section = "1"
 heapless = "0.9"
 static_cell = "2"
 enumset = { version = "1", default-features = false }
-rand_core = "0.9"
+rand_core = "0.10.1"
 mbedtls-rs = { path = "../../mbedtls-rs", features = ["log", "hook-wall-clock"] }
 sha1 = { version = "0.10", default-features = false }
 tinyrlibc = { version = "0.5", default-features = false, features = ["memchr"] }
 
 embassy-time = "0.5"
-embassy-executor = "0.9"
+embassy-executor = "0.10"
 embassy-net = "0.8"
 
 # For the `edge_*` examples
 edge-http = { version = "0.7", features = ["io"] }
 edge-nal-embassy = "0.8"
 
-esp-rtos = { version = "0.2", features = ["esp-radio", "embassy"] }
-esp-hal = { version = "1", features = ["log-04", "unstable", "exception-handler"] }
-esp-alloc = { version = "0.9" }
-esp-backtrace = { version = "0.18.1", features = ["panic-handler", "println"] }
-esp-println = { version = "0.16", optional = true, features = ["log-04"] }
-esp-radio = { version = "0.17", features = ["wifi", "log-04", "unstable"] }
-esp-bootloader-esp-idf = { version = "0.4", features = ["log-04"] }
-esp-metadata-generated = "0.3"
-#esp-rom-sys = "0.1"
+esp-rtos = { version = "0.3", features = ["esp-radio", "embassy"] }
+esp-hal = { version = "~1.1.0", features = ["log-04", "unstable", "exception-handler"] }
+esp-alloc = { version = "0.10" }
+esp-backtrace = { version = "0.19.0", features = ["panic-handler", "println"] }
+esp-println = { version = "0.17", optional = true, features = ["log-04"] }
+esp-radio = { version = "0.18", features = ["wifi", "log-04", "unstable"] }
+esp-bootloader-esp-idf = { version = "0.5", features = ["log-04"] }
+esp-metadata-generated = "0.4"

--- a/examples/esp/src/bin/server.rs
+++ b/examples/esp/src/bin/server.rs
@@ -51,8 +51,8 @@ async fn main(spawner: Spawner) {
 
     let tls = mk_static!(Tls, tls);
 
-    spawner.spawn(http_task("Task 1", tls, stack)).ok();
-    spawner.spawn(http_task("Task 2", tls, stack)).ok();
+    spawner.spawn(http_task("Task 1", tls, stack).unwrap());
+    spawner.spawn(http_task("Task 2", tls, stack).unwrap());
 
     // Don't exit so that the acceleration routines can stay registered
     core::future::pending::<()>().await

--- a/examples/esp/src/bootstrap.rs
+++ b/examples/esp/src/bootstrap.rs
@@ -27,12 +27,12 @@ use esp_metadata_generated::memory_range;
 use esp_radio as _;
 use esp_radio::wifi::scan::ScanConfig;
 use esp_radio::wifi::sta::StationConfig;
-use esp_radio::wifi::ModeConfig;
+use esp_radio::wifi::Config;
+use esp_radio::wifi::ControllerConfig;
+use esp_radio::wifi::Interface;
 use esp_radio::wifi::WifiController;
-use esp_radio::wifi::WifiDevice;
-use esp_radio::wifi::WifiEvent;
 
-use log::info;
+use log::{error, info};
 
 extern crate alloc;
 
@@ -117,9 +117,20 @@ pub async fn bootstrap_stack<const SOCKETS: usize>(
 
     let trng = mk_static!(Trng, Trng::try_new().unwrap());
 
+    let station_config = Config::Station(
+        StationConfig::default()
+            .with_ssid(WIFI_SSID)
+            .with_password(WIFI_PASS.into()),
+    );
+
     // Configure and start the Wifi first
-    let (controller, wifi_interfaces) =
-        esp_radio::wifi::new(peripherals.WIFI, esp_radio::wifi::Config::default()).unwrap();
+    info!("Starting wifi");
+    let (mut controller, wifi_interfaces) = esp_radio::wifi::new(
+        peripherals.WIFI,
+        ControllerConfig::default().with_initial_config(station_config),
+    )
+    .unwrap();
+    info!("Wifi configured and started!");
     let config = embassy_net::Config::dhcpv4(Default::default());
 
     let seed = (trng.random() as u64) << 32 | trng.random() as u64;
@@ -127,8 +138,15 @@ pub async fn bootstrap_stack<const SOCKETS: usize>(
     // Init network stack
     let (stack, runner) = embassy_net::new(wifi_interfaces.station, config, stack_resources, seed);
 
-    spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(runner)).ok();
+    info!("Scan");
+    let scan_config = ScanConfig::default().with_max(10);
+    let result = controller.scan_async(&scan_config).await.unwrap();
+    for ap in result {
+        info!("{:?}", ap);
+    }
+
+    spawner.spawn(connection(controller).unwrap());
+    spawner.spawn(net_task(runner).unwrap());
 
     wait_ip(stack).await;
 
@@ -155,52 +173,29 @@ async fn wait_ip(stack: Stack<'_>) {
 
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
-    info!("Start connection task");
-    info!("Device capabilities: {:?}", controller.capabilities());
+    info!("start connection task");
 
     loop {
-        if matches!(controller.is_connected(), Ok(true)) {
-            // wait until we're no longer connected
-            controller
-                .wait_for_event(WifiEvent::StationDisconnected)
-                .await;
-            Timer::after(Duration::from_millis(5000)).await
-        }
-
-        if !matches!(controller.is_started(), Ok(true)) {
-            let station_config = ModeConfig::Station(
-                StationConfig::default()
-                    .with_ssid(WIFI_SSID.into())
-                    .with_password(WIFI_PASS.into()),
-            );
-            controller.set_config(&station_config).unwrap();
-            info!("Starting wifi");
-            controller.start_async().await.unwrap();
-            info!("Wifi started!");
-
-            info!("Scan");
-            let scan_config = ScanConfig::default().with_max(10);
-            let result = controller
-                .scan_with_config_async(scan_config)
-                .await
-                .unwrap();
-            for ap in result {
-                info!("{:?}", ap);
-            }
-        }
         info!("About to connect...");
 
         match controller.connect_async().await {
-            Ok(_) => info!("Wifi connected!"),
+            Ok(info) => {
+                info!("Wifi connected to {:?}", info);
+
+                // wait until we're no longer connected
+                let info = controller.wait_for_disconnect_async().await.ok();
+                error!("Disconnected: {:?}", info);
+            }
             Err(e) => {
-                info!("Failed to connect to wifi: {e:?}");
-                Timer::after(Duration::from_millis(5000)).await
+                error!("Failed to connect to wifi: {e:?}");
             }
         }
+
+        Timer::after(Duration::from_millis(5000)).await
     }
 }
 
 #[embassy_executor::task]
-async fn net_task(mut runner: Runner<'static, WifiDevice<'static>>) {
+async fn net_task(mut runner: Runner<'static, Interface<'static>>) {
     runner.run().await
 }

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -23,7 +23,7 @@ enumset = { version = "1", default-features = false }
 edge-http = { version = "0.7", features = ["io"] }
 
 # STD-only dependencies
-rand = "0.9"
+rand = "0.10"
 critical-section = { version = "1", features = ["std"] }
 embedded-io-adapters = { version = "0.7", features = ["std", "futures-03"] }
 async-io-mini = "0.4"

--- a/mbedtls-rs-sys/Cargo.toml
+++ b/mbedtls-rs-sys/Cargo.toml
@@ -55,7 +55,7 @@ time = { version = "0.3", default-features = false, optional = true }
 critical-section = "1"
 
 # For esp-hal hook impls
-esp-hal = { version = "1", features = ["unstable"], optional = true }
+esp-hal = { version = "~1.1.0", features = ["unstable"], optional = true }
 crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"], optional = true }
 
 # For embassy timer hook impl

--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -575,7 +575,13 @@ impl CMakeConfigurer {
 
     fn derive_forced_c_compiler(&self) -> Option<(PathBuf, bool)> {
         if self.force_clang {
-            Some((PathBuf::from("clang"), false))
+            Some((
+                std::env::var_os("CLANG_PATH")
+                    .filter(|path| !path.is_empty())
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("clang")),
+                false,
+            ))
         } else {
             match self.target().as_str() {
                 "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => {

--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -50,6 +50,6 @@ log = { version = "0.4", default-features = false, optional = true }
 embedded-io = { version = "0.7" }
 embedded-io-async = { version = "0.7" }
 enumset = { version = "1", default-features = false }
-rand_core = "0.9"
+rand_core = "0.10.1"
 critical-section = "1"
 edge-nal = { version = "0.6", optional = true }


### PR DESCRIPTION
This extracts **only** the update to esp-hal 1.1 from the (now stalled?) #122.

(
Another extraction will submit as a PR the GCC fix and the CI update which now also does a GCC build.
A third extraction might update edge-net and so on.

... to keep the changeset manageable.
)