### PR TITLE
Bindgen allowlist for GCC time_t backing types

### DIFF
--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -239,7 +239,10 @@ impl MbedtlsBuilder {
         }
 
         if self.hooks.contains(Hook::Timer) {
-            builder = builder.allowlist_item("time_t");
+            builder = builder
+                .allowlist_item("time_t")
+                .allowlist_item("__int_least64_t")
+                .allowlist_item("__int64_t");
         }
 
         if self.hooks.contains(Hook::WallClock) {


### PR DESCRIPTION
This PR contains only the small change that fixes the build breakage with (some?) GCC compilers - from #122.

Some GCC variants expand time_t through __int_least64_t / __int64_t. Without these in the bindgen allowlist, generated bindings fail to compile when the timer hook is enabled.