### PR TITLE
Enable nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "00 7 * * *"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Runs the CI GH action every night, so as to catch any failures cause by changes to dependencies.