### PR TITLE
Expose granular algorithm selection; stop forcing the full `tls` profile

### DIFF
--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -12,9 +12,98 @@ readme = "README.md"
 harness = false
 
 [features]
-default = ["edge-nal"]
+# `profile-tls` reproduces the historical full algorithm surface and is ON by
+# default, so existing consumers are unchanged. Consumers wanting a smaller build
+# set `default-features = false` and select a curated bundle (`tls`/`openthread`/
+# `matter`) or any individual `alg-*`/`curve-*`/`cipher-mode-*`/`kex-*`/… leaf below.
+default = ["edge-nal", "profile-tls"]
 defmt = ["dep:defmt", "mbedtls-rs-sys/defmt"]
 log = ["dep:log", "mbedtls-rs-sys/log"]
+
+# ─── Algorithm profile selection (granular passthrough to mbedtls-rs-sys) ───
+profile-tls = ["mbedtls-rs-sys/tls"]
+
+# Curated bundles
+openthread = ["mbedtls-rs-sys/openthread"]
+matter = ["mbedtls-rs-sys/matter"]
+tls = ["mbedtls-rs-sys/tls"]
+
+# Individual algorithm leaves (one per independently-linkable MbedTLS unit)
+alg-sha256 = ["mbedtls-rs-sys/alg-sha256"]
+alg-sha512 = ["mbedtls-rs-sys/alg-sha512"]
+alg-sha1 = ["mbedtls-rs-sys/alg-sha1"]
+alg-md5 = ["mbedtls-rs-sys/alg-md5"]
+alg-ripemd160 = ["mbedtls-rs-sys/alg-ripemd160"]
+alg-aes = ["mbedtls-rs-sys/alg-aes"]
+alg-des = ["mbedtls-rs-sys/alg-des"]
+alg-aria = ["mbedtls-rs-sys/alg-aria"]
+alg-camellia = ["mbedtls-rs-sys/alg-camellia"]
+alg-chacha20 = ["mbedtls-rs-sys/alg-chacha20"]
+cipher-mode-cbc = ["mbedtls-rs-sys/cipher-mode-cbc"]
+cipher-mode-cfb = ["mbedtls-rs-sys/cipher-mode-cfb"]
+cipher-mode-ofb = ["mbedtls-rs-sys/cipher-mode-ofb"]
+cipher-mode-ctr = ["mbedtls-rs-sys/cipher-mode-ctr"]
+cipher-mode-xts = ["mbedtls-rs-sys/cipher-mode-xts"]
+alg-gcm = ["mbedtls-rs-sys/alg-gcm"]
+alg-ccm = ["mbedtls-rs-sys/alg-ccm"]
+alg-cmac = ["mbedtls-rs-sys/alg-cmac"]
+alg-chachapoly = ["mbedtls-rs-sys/alg-chachapoly"]
+alg-nist-kw = ["mbedtls-rs-sys/alg-nist-kw"]
+alg-rsa = ["mbedtls-rs-sys/alg-rsa"]
+alg-rsa-pss = ["mbedtls-rs-sys/alg-rsa-pss"]
+alg-dhm = ["mbedtls-rs-sys/alg-dhm"]
+alg-ecp = ["mbedtls-rs-sys/alg-ecp"]
+alg-ecdh = ["mbedtls-rs-sys/alg-ecdh"]
+alg-ecdsa = ["mbedtls-rs-sys/alg-ecdsa"]
+alg-ecjpake = ["mbedtls-rs-sys/alg-ecjpake"]
+pk = ["mbedtls-rs-sys/pk"]
+curve-secp192r1 = ["mbedtls-rs-sys/curve-secp192r1"]
+curve-secp224r1 = ["mbedtls-rs-sys/curve-secp224r1"]
+curve-secp256r1 = ["mbedtls-rs-sys/curve-secp256r1"]
+curve-secp384r1 = ["mbedtls-rs-sys/curve-secp384r1"]
+curve-secp521r1 = ["mbedtls-rs-sys/curve-secp521r1"]
+curve-secp192k1 = ["mbedtls-rs-sys/curve-secp192k1"]
+curve-secp224k1 = ["mbedtls-rs-sys/curve-secp224k1"]
+curve-secp256k1 = ["mbedtls-rs-sys/curve-secp256k1"]
+curve-bp256r1 = ["mbedtls-rs-sys/curve-bp256r1"]
+curve-bp384r1 = ["mbedtls-rs-sys/curve-bp384r1"]
+curve-bp512r1 = ["mbedtls-rs-sys/curve-bp512r1"]
+curve-curve25519 = ["mbedtls-rs-sys/curve-curve25519"]
+curve-curve448 = ["mbedtls-rs-sys/curve-curve448"]
+alg-hkdf = ["mbedtls-rs-sys/alg-hkdf"]
+alg-pkcs5 = ["mbedtls-rs-sys/alg-pkcs5"]
+alg-pkcs12 = ["mbedtls-rs-sys/alg-pkcs12"]
+drbg-ctr = ["mbedtls-rs-sys/drbg-ctr"]
+drbg-hmac = ["mbedtls-rs-sys/drbg-hmac"]
+entropy = ["mbedtls-rs-sys/entropy"]
+base64 = ["mbedtls-rs-sys/base64"]
+pem-parse = ["mbedtls-rs-sys/pem-parse"]
+pem-write = ["mbedtls-rs-sys/pem-write"]
+pkcs7 = ["mbedtls-rs-sys/pkcs7"]
+x509-parse = ["mbedtls-rs-sys/x509-parse"]
+x509-write = ["mbedtls-rs-sys/x509-write"]
+tls-engine = ["mbedtls-rs-sys/tls-engine"]
+tls-core = ["mbedtls-rs-sys/tls-core"]
+tls-client = ["mbedtls-rs-sys/tls-client"]
+tls-server = ["mbedtls-rs-sys/tls-server"]
+tls-cache = ["mbedtls-rs-sys/tls-cache"]
+tls-ticket = ["mbedtls-rs-sys/tls-ticket"]
+tls-debug = ["mbedtls-rs-sys/tls-debug"]
+tls-proto-tls12 = ["mbedtls-rs-sys/tls-proto-tls12"]
+tls-proto-tls13 = ["mbedtls-rs-sys/tls-proto-tls13"]
+tls-proto-dtls = ["mbedtls-rs-sys/tls-proto-dtls"]
+kex-psk = ["mbedtls-rs-sys/kex-psk"]
+kex-ecdhe-ecdsa = ["mbedtls-rs-sys/kex-ecdhe-ecdsa"]
+kex-ecdhe-rsa = ["mbedtls-rs-sys/kex-ecdhe-rsa"]
+kex-ecdh-ecdsa = ["mbedtls-rs-sys/kex-ecdh-ecdsa"]
+kex-ecdh-rsa = ["mbedtls-rs-sys/kex-ecdh-rsa"]
+kex-rsa = ["mbedtls-rs-sys/kex-rsa"]
+kex-rsa-psk = ["mbedtls-rs-sys/kex-rsa-psk"]
+kex-dhe-rsa = ["mbedtls-rs-sys/kex-dhe-rsa"]
+kex-dhe-psk = ["mbedtls-rs-sys/kex-dhe-psk"]
+kex-ecdhe-psk = ["mbedtls-rs-sys/kex-ecdhe-psk"]
+kex-ecjpake = ["mbedtls-rs-sys/kex-ecjpake"]
+platform-zeroize-alt = ["mbedtls-rs-sys/platform-zeroize-alt"]
 
 # Re-expose mbedtls-rs-sys features
 use-gcc = ["mbedtls-rs-sys/use-gcc"]
@@ -48,11 +137,11 @@ esp32s3 = ["mbedtls-rs-sys/esp32s3"]
 embassy-time = ["mbedtls-rs-sys/embassy-time"]
 
 [dependencies]
-# `mbedtls-rs` provides TLS streams, which need the full algorithm surface
-# (`MBEDTLS_SSL_PRESET_DEFAULT`): TLS 1.2/1.3 ciphersuites, RSA/ECDSA, the
-# default X.509 verification profile, etc. So the `tls` profile of
-# `mbedtls-rs-sys` is always enabled.
-mbedtls-rs-sys = { path = "../mbedtls-rs-sys", default-features = false, features = ["tls"] }
+# Algorithm surface is selected by the consumer via this crate's profile/leaf
+# features (default = `profile-tls` = full historical surface). No profile is
+# hard-wired here, so `default-features = false` + leaf selection yields a
+# minimal build. See the `[features]` section above.
+mbedtls-rs-sys = { path = "../mbedtls-rs-sys", default-features = false }
 defmt = { version = "1", optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 embedded-io = { version = "0.7" }

--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -12,17 +12,17 @@ readme = "README.md"
 harness = false
 
 [features]
-# `profile-tls` reproduces the historical full algorithm surface and is ON by
+# The `tls` bundle reproduces the historical full algorithm surface and is ON by
 # default, so existing consumers are unchanged. Consumers wanting a smaller build
 # set `default-features = false` and select a curated bundle (`tls`/`openthread`/
-# `matter`) or any individual `alg-*`/`curve-*`/`cipher-mode-*`/`kex-*`/… leaf below.
-default = ["edge-nal", "profile-tls"]
+# `matter`) or any individual `alg-*`/`curve-*`/`cipher-mode-*`/`kex-*`/... leaf below.
+# Even with `default-features = false` and no bundle, a minimal non-negotiable floor
+# (see the `mbedtls-rs-sys` dependency below) keeps this crate compiling.
+default = ["edge-nal", "tls"]
 defmt = ["dep:defmt", "mbedtls-rs-sys/defmt"]
 log = ["dep:log", "mbedtls-rs-sys/log"]
 
 # ─── Algorithm profile selection (granular passthrough to mbedtls-rs-sys) ───
-profile-tls = ["mbedtls-rs-sys/tls"]
-
 # Curated bundles
 openthread = ["mbedtls-rs-sys/openthread"]
 matter = ["mbedtls-rs-sys/matter"]
@@ -137,11 +137,21 @@ esp32s3 = ["mbedtls-rs-sys/esp32s3"]
 embassy-time = ["mbedtls-rs-sys/embassy-time"]
 
 [dependencies]
-# Algorithm surface is selected by the consumer via this crate's profile/leaf
-# features (default = `profile-tls` = full historical surface). No profile is
-# hard-wired here, so `default-features = false` + leaf selection yields a
-# minimal build. See the `[features]` section above.
-mbedtls-rs-sys = { path = "../mbedtls-rs-sys", default-features = false }
+# Algorithm surface is selected by the consumer via this crate's bundle/leaf
+# features (default = `tls` = full historical surface). The fixed feature list
+# below is the minimal non-negotiable floor that keeps THIS crate compiling even
+# under `--no-default-features` (a coherent minimal EC TLS 1.2/1.3 stack: the SSL
+# engine, X.509 + PK + PEM parse, ECDHE-ECDSA over P-256, AES-GCM, SHA-256, HKDF,
+# CTR-DRBG + entropy). Consumer-selected bundles/leaves are unioned on top.
+mbedtls-rs-sys = { path = "../mbedtls-rs-sys", default-features = false, features = [
+    "tls-engine", "tls-core", "tls-client", "tls-server",
+    "tls-proto-tls12", "tls-proto-tls13",
+    "kex-ecdhe-ecdsa",
+    "alg-sha256", "alg-aes", "alg-gcm", "alg-hkdf",
+    "alg-ecp", "alg-ecdh", "alg-ecdsa", "pk",
+    "curve-secp256r1",
+    "drbg-ctr", "entropy", "base64", "pem-parse", "x509-parse",
+] }
 defmt = { version = "1", optional = true }
 log = { version = "0.4", default-features = false, optional = true }
 embedded-io = { version = "0.7" }


### PR DESCRIPTION
Today `mbedtls-rs` hard-wires `mbedtls-rs-sys`'s full `tls` profile, so every consumer compiles in the entire algorithm surface (all curves, RSA, DHM, every cipher mode) even when they only ever speak one suite. There's no way to trim from the high-level crate, since Cargo features are additive: a downstream crate can't subtract the `tls` that `mbedtls-rs` turns on.

That hurts on memory-constrained bare-metal targets. Concrete case: an ESP32-C5 firmware with 384 KB SRAM, where the TLS 1.3 handshake already needs ~46 KB of contiguous heap. The unused EC curve and ciphersuite tables are ~8 KB of pure `.data` we can't spare, and the deployment is P-256 / ECDSA only; RSA, DHM, brainpool and the secp-k1 / 521 curves are all dead weight.

This PR makes the algorithm surface selectable from `mbedtls-rs`, mirroring what `mbedtls-rs-sys` already exposes (#139):

- **`profile-tls` is a default feature** (= today's full surface), so existing default consumers are unchanged.
- The `tls` / `openthread` / `matter` bundles and every individual leaf (`alg-*`, `curve-*`, `cipher-mode-*`, `kex-*`, `pk`, `drbg-*`, `pem-*`, `x509-*`, ...) are re-exposed as thin 1:1 passthroughs, with no new logic.
- The hard-wired `features = ["tls"]` on the sys dependency is dropped; the profile now flows through these features.

Measured result downstream, with a P-256-only profile and identical numbers across ESP32-C3/C5/C6: **-7.8 KB `.data`**. On the C5 that converts straight into ~**+8 KB of usable task stack** (the linker hands freed DRAM to the stack region). HTTPS and the SHA-256 OTA FFI path build clean; RSA is fully absent from the image.

**Behavior note:** consumers using `default-features = false` previously still received the full `tls` set (it was forced regardless of their feature selection). They'll now need to opt into a profile or specific leaves. That's the intended fix, but worth flagging as a breaking change for that subset.

Happy to add matching feature docs to the README if you'd like them in the same PR.
