### PR TITLE
Gate Tls::set_debug behind tls-debug to fix a no-default-features link error

### DIFF
--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -24,9 +24,11 @@ log = ["dep:log", "mbedtls-rs-sys/log"]
 
 # ─── Algorithm profile selection (granular passthrough to mbedtls-rs-sys) ───
 # Curated bundles
-openthread = ["mbedtls-rs-sys/openthread"]
+# `tls`/`openthread` compile in MBEDTLS_DEBUG_C, so they also enable local
+# `tls-debug` (which gates `Tls::set_debug`); `matter` must NOT (no DEBUG_C).
+openthread = ["mbedtls-rs-sys/openthread", "tls-debug"]
 matter = ["mbedtls-rs-sys/matter"]
-tls = ["mbedtls-rs-sys/tls"]
+tls = ["mbedtls-rs-sys/tls", "tls-debug"]
 
 # Individual algorithm leaves (one per independently-linkable MbedTLS unit)
 alg-sha256 = ["mbedtls-rs-sys/alg-sha256"]

--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -88,10 +88,17 @@ impl<'d> Tls<'d> {
         });
     }
 
-    /// Set the MbedTLS debug level (0 - 5)
+    /// Set the MbedTLS debug level (0 - 5).
+    ///
+    /// No-op unless the `tls-debug` feature is enabled (the `tls`/`openthread`
+    /// bundles enable it) so `MBEDTLS_DEBUG_C` is compiled in; also a no-op on
+    /// ESP-IDF.
     #[allow(unused)]
     pub fn set_debug(&mut self, level: u32) {
-        #[cfg(not(target_os = "espidf"))]
+        #[cfg(all(not(target_os = "espidf"), feature = "tls-debug"))]
+        // SAFETY: this block is compiled only when `tls-debug` is enabled, which turns on
+        // `mbedtls-rs-sys/tls-debug` (MBEDTLS_DEBUG_C) so `mbedtls_debug_set_threshold` is
+        // defined and linked; the call passes one `c_int` by value (no pointers/aliasing).
         unsafe {
             use crate::sys::mbedtls_debug_set_threshold;
 


### PR DESCRIPTION
## Problem

Building `mbedtls-rs` with `--no-default-features` selects the minimal `mbedtls-rs-sys` floor introduced in #142, which does not include `tls-debug`. With `MBEDTLS_DEBUG_C` off, `mbedtls_debug_set_threshold` has a prototype (`debug.h`) but no definition (`debug.c` defines it only under `MBEDTLS_DEBUG_C`). Any binary that calls `Tls::set_debug()` in that configuration fails to link with an undefined reference.

## Fix

Gate the `set_debug` FFI call behind the `tls-debug` feature, and have the `tls` and `openthread` bundles enable it (both compile in `MBEDTLS_DEBUG_C`). `matter` and the bare `--no-default-features` floor deliberately do not, so `set_debug` is a no-op there. The method stays public in every configuration (no-op without `tls-debug` or on ESP-IDF), matching its existing ESP-IDF no-op behavior. `mbedtls_ssl_conf_dbg` / debug callbacks are unconditional and unaffected.

## Verification

Built locally on host `x86_64-unknown-linux-gnu`:

- `cargo build -p mbedtls-rs` (default, `tls-debug` on) — OK
- `cargo build -p mbedtls-rs --no-default-features` (`tls-debug` off) — OK
- `nm` on the compiled rlib: the default build references `mbedtls_debug_set_threshold` (resolved by the sys lib that defines it); the `--no-default-features` build no longer references it at all, eliminating the undefined symbol.

<details>
<summary><b>Build &amp; symbol evidence</b> — click to expand</summary>

```text
$ rustc -vV
host: x86_64-unknown-linux-gnu
release: 1.96.0

$ cargo build -p mbedtls-rs                          # default features (tls-debug ON)
   Compiling mbedtls-rs v0.1.0 (mbedtls-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.57s

$ cargo build -p mbedtls-rs --no-default-features    # tls-debug OFF
   Compiling mbedtls-rs v0.1.0 (mbedtls-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.47s

# Symbol-level proof  (nm on the produced rlib):

$ nm <default rlib> | grep mbedtls_debug_set_threshold
                 U mbedtls_debug_set_threshold
  -> referenced (U); resolved by the sys lib, which defines it when MBEDTLS_DEBUG_C is on

$ nm <--no-default-features rlib> | grep mbedtls_debug_set_threshold
(no match) -> symbol not referenced -> no undefined reference -> no link error
```

</details>

Follow-up to #142.
