### PR TITLE
Allow tuning the TLS record buffer sizes to reduce per-connection RAM

### DIFF
--- a/mbedtls-rs-sys/Cargo.toml
+++ b/mbedtls-rs-sys/Cargo.toml
@@ -28,6 +28,29 @@ default = ["tls"]
 # hooks match this profile exactly.
 prebuilt = ["tls"]
 
+# ─── TLS record buffer sizing (per-connection RAM) ───
+# Cap MBEDTLS_SSL_IN/OUT_CONTENT_LEN below the 16384 default to shrink the
+# per-connection record buffers. Cargo features are additive, so when several
+# sizes are selected across the dependency graph the LARGEST wins (a bigger
+# record buffer is always safe). None selected — or the `-16384` entry — keeps
+# MbedTLS's default and reuses the prebuilt libraries; any smaller value forces
+# an on-the-fly MbedTLS rebuild. Keep in sync with
+# `gen/features.rs::SSL_CONTENT_LEN_SIZES`.
+ssl-in-content-len-256 = []
+ssl-in-content-len-512 = []
+ssl-in-content-len-1024 = []
+ssl-in-content-len-2048 = []
+ssl-in-content-len-4096 = []
+ssl-in-content-len-8192 = []
+ssl-in-content-len-16384 = []
+ssl-out-content-len-256 = []
+ssl-out-content-len-512 = []
+ssl-out-content-len-1024 = []
+ssl-out-content-len-2048 = []
+ssl-out-content-len-4096 = []
+ssl-out-content-len-8192 = []
+ssl-out-content-len-16384 = []
+
 # Always generate the bindings during build, even if pre-built bindings for the build target are available
 force-generate-bindings = []
 # Use GCC instead of clang

--- a/mbedtls-rs-sys/README.md
+++ b/mbedtls-rs-sys/README.md
@@ -34,6 +34,20 @@ ESP-IDF is also supported and in that case `mbedtls-rs-sys` becomes just an alia
 
 **NOTE:**: on-the-fly compilation can be forced by using the `force-generate-bindings` feature.
 
+## Tuning TLS record buffer sizes (RAM)
+
+By default MbedTLS allocates two ~16 KiB record-plaintext buffers **per TLS connection** (`MBEDTLS_SSL_IN_CONTENT_LEN` / `MBEDTLS_SSL_OUT_CONTENT_LEN` default to `16384`), i.e. ~32 KiB of heap per connection. On RAM-constrained MCUs you can shrink these with the `ssl-in-content-len-<N>` / `ssl-out-content-len-<N>` features (`N` one of `256, 512, 1024, 2048, 4096, 8192, 16384`):
+
+```toml
+mbedtls-rs-sys = { version = "...", features = ["ssl-in-content-len-4096", "ssl-out-content-len-2048"] }
+```
+
+(The `mbedtls-rs` crate re-exposes the same features.)
+
+- **Additive:** Cargo features unify across the dependency graph, so if several `ssl-in-content-len-*` (or `-out-`) are enabled the **largest wins** — a bigger buffer is always safe for the consumer that asked for a smaller one.
+- **Default-preserving:** selecting none (or `-16384`) keeps MbedTLS's default and reuses the committed prebuilt `.a` libraries. A smaller size is `#define`d into the MbedTLS config, which **forces an on-the-fly MbedTLS rebuild** (so `clang`/`cmake`/`ninja` must be installed — see above). A Max-Fragment-Length (MFL) negotiation alone does *not* shrink these buffers; only `*_CONTENT_LEN` does.
+- **`IN` is the risky one:** if the incoming buffer is smaller than a record the peer sends, the handshake/read fails. A **client** lowering `IN` should request MFL ≤ `IN`; a **server** cannot force arbitrary clients to send smaller records, so keep its `IN` conservative. `OUT` is usually less constrained, but an `OUT` smaller than an outgoing handshake message (e.g. a large client certificate chain in mTLS) will also fail the handshake.
+
 ## Hooking (for HW accel)
 
 Putting aside the new PSA Crypto driver layer, MbedTLS 3.X has a relatively simplistic approach ("_ALT" macros) towards hardware acceleration.

--- a/mbedtls-rs-sys/gen/features.rs
+++ b/mbedtls-rs-sys/gen/features.rs
@@ -540,6 +540,52 @@ pub fn apply_features(config: &mut MbedtlsUserConfig) {
     build_config(config, |feature| {
         std::env::var_os(format!("CARGO_FEATURE_{feature}")).is_some()
     });
+    apply_ssl_content_len_overrides(config);
+}
+
+/// The selectable `MBEDTLS_SSL_IN_CONTENT_LEN` / `MBEDTLS_SSL_OUT_CONTENT_LEN`
+/// sizes, each exposed as an `ssl-{in,out}-content-len-<N>` cargo feature (see
+/// Cargo.toml). Cargo features are additive, so when several are enabled across
+/// the dependency graph the LARGEST is used — a bigger record buffer is always
+/// safe for the consumer that asked for a smaller one. Keep in sync with the
+/// `ssl-*-content-len-*` feature lists in Cargo.toml.
+pub const SSL_CONTENT_LEN_SIZES: &[usize] = &[256, 512, 1024, 2048, 4096, 8192, 16384];
+
+/// Apply the consumer-selected TLS record-buffer sizes (the
+/// `ssl-{in,out}-content-len-<N>` features) to `config`.
+///
+/// These cap the per-connection record-plaintext buffers MbedTLS `calloc`s in
+/// `mbedtls_ssl_setup`. The largest enabled size per direction wins (additive
+/// features). No size selected — or `16384`, MbedTLS's default — leaves the
+/// macro undefined so the committed prebuilt libraries are reused; any smaller
+/// value is `#define`d, which (being absent from the prebuilt reference config
+/// in `prebuilt_features_config`) registers as a config delta and forces an
+/// on-the-fly MbedTLS rebuild. Applied only here, never to the prebuilt
+/// reference, so the override is always visible as a delta against the `.a`.
+fn apply_ssl_content_len_overrides(config: &mut MbedtlsUserConfig) {
+    // The committed prebuilt artifacts are always built at MbedTLS's default
+    // buffer size, so ignore the size features while generating them (xtask's
+    // `prebuilt` profile) — otherwise the desync guard in build.rs would reject
+    // its own output.
+    if std::env::var_os("CARGO_FEATURE_PREBUILT").is_some() {
+        return;
+    }
+
+    const DEFAULT_CONTENT_LEN: usize = 16384;
+
+    for ident in ["SSL_IN_CONTENT_LEN", "SSL_OUT_CONTENT_LEN"] {
+        let selected = SSL_CONTENT_LEN_SIZES
+            .iter()
+            .copied()
+            .filter(|n| std::env::var_os(format!("CARGO_FEATURE_{ident}_{n}")).is_some())
+            .max();
+
+        if let Some(value) = selected {
+            if value != DEFAULT_CONTENT_LEN {
+                config.set(ident, value.to_string());
+            }
+        }
+    }
 }
 
 /// Build the algorithm-selection config the *prebuilt* artifacts correspond to

--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -105,6 +105,22 @@ kex-ecdhe-psk = ["mbedtls-rs-sys/kex-ecdhe-psk"]
 kex-ecjpake = ["mbedtls-rs-sys/kex-ecjpake"]
 platform-zeroize-alt = ["mbedtls-rs-sys/platform-zeroize-alt"]
 
+# TLS record buffer sizing (per-connection RAM) — passthrough to mbedtls-rs-sys.
+ssl-in-content-len-256 = ["mbedtls-rs-sys/ssl-in-content-len-256"]
+ssl-in-content-len-512 = ["mbedtls-rs-sys/ssl-in-content-len-512"]
+ssl-in-content-len-1024 = ["mbedtls-rs-sys/ssl-in-content-len-1024"]
+ssl-in-content-len-2048 = ["mbedtls-rs-sys/ssl-in-content-len-2048"]
+ssl-in-content-len-4096 = ["mbedtls-rs-sys/ssl-in-content-len-4096"]
+ssl-in-content-len-8192 = ["mbedtls-rs-sys/ssl-in-content-len-8192"]
+ssl-in-content-len-16384 = ["mbedtls-rs-sys/ssl-in-content-len-16384"]
+ssl-out-content-len-256 = ["mbedtls-rs-sys/ssl-out-content-len-256"]
+ssl-out-content-len-512 = ["mbedtls-rs-sys/ssl-out-content-len-512"]
+ssl-out-content-len-1024 = ["mbedtls-rs-sys/ssl-out-content-len-1024"]
+ssl-out-content-len-2048 = ["mbedtls-rs-sys/ssl-out-content-len-2048"]
+ssl-out-content-len-4096 = ["mbedtls-rs-sys/ssl-out-content-len-4096"]
+ssl-out-content-len-8192 = ["mbedtls-rs-sys/ssl-out-content-len-8192"]
+ssl-out-content-len-16384 = ["mbedtls-rs-sys/ssl-out-content-len-16384"]
+
 # Re-expose mbedtls-rs-sys features
 use-gcc = ["mbedtls-rs-sys/use-gcc"]
 force-generate-bindings = ["mbedtls-rs-sys/force-generate-bindings"]


### PR DESCRIPTION
## Problem

MbedTLS allocates `MBEDTLS_SSL_IN_CONTENT_LEN` + `MBEDTLS_SSL_OUT_CONTENT_LEN` record-plaintext buffers **per TLS connection**. Both default to `16384`, so every connection costs ~32 KB of heap — the dominant RAM cost on memory-constrained MCUs. Negotiating a smaller Max-Fragment-Length does **not** shrink these buffers (they are `calloc`d at the compiled `*_CONTENT_LEN` size in `mbedtls_ssl_setup`); only lowering `*_CONTENT_LEN` does. And since the committed prebuilt `.a` libraries bake in `16384`, a header/user-config override alone cannot resize them.

## Change

`ssl-in-content-len-<N>` / `ssl-out-content-len-<N>` cargo features (`N` one of `256, 512, 1024, 2048, 4096, 8192, 16384`), re-exposed 1:1 by `mbedtls-rs`:

```toml
mbedtls-rs = { version = "...", features = ["ssl-in-content-len-4096", "ssl-out-content-len-2048"] }
```

- **Additive — largest wins:** Cargo features unify across the dependency graph, so if several `ssl-in-content-len-*` (or `-out-`) are enabled, the largest is used — always safe for the consumer that asked for a smaller buffer.
- Applied in `features::apply_features`, so the selection feeds **both** the prebuilt-validity check and the actual compile config. It is absent from the prebuilt reference (`prebuilt_features_config`), so a non-default size registers as a config delta and **forces an on-the-fly MbedTLS rebuild** (needs `clang`/`cmake`/`ninja`).
- **Default-preserving:** selecting nothing (or `-16384`) keeps MbedTLS's default and reuses the committed prebuilt libraries — existing consumers are unaffected.
- Skipped under the `prebuilt` profile, so `xtask` always regenerates default-sized artifacts (and the selection never trips `build.rs`'s desync guard).

Docs added to the `mbedtls-rs-sys` README, including the `IN`-too-low / `OUT`-too-low handshake-failure caveats.

> Reworked per @ivmarkov's review — cargo features instead of env vars, biggest-prevails — following the `openthread-sys` `heap-int-*` convention.

## Verification

Built on host, target `riscv32imc-unknown-none-elf`:

<details>
<summary><b>Build evidence</b> — click to expand</summary>

```text
# default (no feature) -> prebuilt reused, no rebuild
$ cargo build -p mbedtls-rs-sys --target riscv32imc-unknown-none-elf            -> Finished (reused)

# features -> prebuilt rejected + on-the-fly rebuild + #defines emitted
$ cargo build -p mbedtls-rs-sys --features ssl-in-content-len-4096,ssl-out-content-len-2048 --target riscv32imc-unknown-none-elf
# generated mbedtls_rs_sys_user_config.h:
#define MBEDTLS_SSL_IN_CONTENT_LEN 4096
#define MBEDTLS_SSL_OUT_CONTENT_LEN 2048

# biggest prevails: ssl-in-content-len-2048 + ssl-in-content-len-4096 -> IN=4096
#define MBEDTLS_SSL_IN_CONTENT_LEN 4096

# ssl-in-content-len-16384 (= default) -> reused, no #define
```

</details>

### Verified on-target (esp32c3 in QEMU)

A no-network firmware measured the heap allocated per `Session::new` on a real esp32c3 boot — `Session::new` runs `mbedtls_ssl_setup` (which `calloc`s the IN/OUT record buffers); the handshake, which needs a peer, is never started:

| Config | heap allocated per `Session::new` |
|---|---|
| default (IN=16384, OUT=16384) | **43,276 B** |
| `ssl-in-content-len-4096` + `ssl-out-content-len-2048` | **16,652 B** |

That is **26,624 B less per session — exactly `(16384 − 4096) + (16384 − 2048)`**: the on-target heap delta drops by precisely the configured buffer reduction.
