### PR TITLE
Expose RFC 6066 Max Fragment Length as a TLS config knob

### DIFF
--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -1,4 +1,4 @@
-use core::ffi::{c_char, c_int, c_void, CStr};
+use core::ffi::{c_char, c_int, c_uchar, c_void, CStr};
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 
@@ -46,6 +46,57 @@ impl AuthMode {
     }
 }
 
+/// RFC 6066 Maximum Fragment Length.
+///
+/// Sets the maximum TLS record *plaintext payload* this endpoint will emit,
+/// subject to the MbedTLS compile-time content lengths
+/// ([`MBEDTLS_SSL_IN_CONTENT_LEN`]/[`MBEDTLS_SSL_OUT_CONTENT_LEN`], i.e. the
+/// `ssl-in-content-len-*`/`ssl-out-content-len-*` features), TLS version
+/// support, and negotiation/peer behavior. On a client the value is also
+/// advertised to the server during the handshake; on a server it caps what the
+/// server emits (normally in response to a client's negotiated value).
+///
+/// # This is NOT a buffer-sizing knob
+///
+/// Per the MbedTLS C source (`ssl.h`), with TLS this currently affects only
+/// `ApplicationData` records, *not* handshake messages. It therefore does
+/// **not** reduce the buffer required to receive a server `Certificate` (a
+/// handshake message) and is **not** a substitute for the
+/// `ssl-in-content-len-*` features when sizing buffers for the handshake. To
+/// actually shrink the record buffers, set those features instead.
+///
+/// # Scope
+///
+/// This is a TLS 1.2 / RFC 6066 mechanism; it has no effect on TLS 1.3, which
+/// uses `record_size_limit` (RFC 8449, not exposed here). The default
+/// [`MaxFragLen::None`] preserves MbedTLS's behavior (no extension sent).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MaxFragLen {
+    /// No Max Fragment Length extension (MbedTLS default; no behavior change).
+    None,
+    /// Cap the record payload at 512 bytes.
+    B512,
+    /// Cap the record payload at 1024 bytes.
+    B1024,
+    /// Cap the record payload at 2048 bytes.
+    B2048,
+    /// Cap the record payload at 4096 bytes.
+    B4096,
+}
+
+impl MaxFragLen {
+    fn mfl_code(&self) -> c_uchar {
+        (match self {
+            MaxFragLen::None => MBEDTLS_SSL_MAX_FRAG_LEN_NONE,
+            MaxFragLen::B512 => MBEDTLS_SSL_MAX_FRAG_LEN_512,
+            MaxFragLen::B1024 => MBEDTLS_SSL_MAX_FRAG_LEN_1024,
+            MaxFragLen::B2048 => MBEDTLS_SSL_MAX_FRAG_LEN_2048,
+            MaxFragLen::B4096 => MBEDTLS_SSL_MAX_FRAG_LEN_4096,
+        }) as c_uchar
+    }
+}
+
 /// The credentials (certificate and private key)
 /// used for client or server authentication
 #[derive(Debug, Clone)]
@@ -79,6 +130,11 @@ pub struct ClientSessionConfig<'a> {
     pub min_version: TlsVersion,
     /// ALPN protocols
     pub alpn_protocols: Option<&'a [&'a CStr]>,
+    /// RFC 6066 Maximum Fragment Length to advertise to the server.
+    /// Defaults to [MaxFragLen::None] (no extension; unchanged behavior).
+    /// See [MaxFragLen] - this caps ApplicationData record payload, not
+    /// handshake buffers.
+    pub max_frag_len: MaxFragLen,
 }
 
 impl<'a> Default for ClientSessionConfig<'a> {
@@ -96,6 +152,7 @@ impl<'a> ClientSessionConfig<'a> {
             auth_mode: AuthMode::Required,
             min_version: TlsVersion::Tls1_2,
             alpn_protocols: None,
+            max_frag_len: MaxFragLen::None,
         }
     }
 }
@@ -118,6 +175,11 @@ pub struct ServerSessionConfig<'a> {
     pub min_version: TlsVersion,
     /// ALPN protocols
     pub alpn_protocols: Option<&'a [&'a CStr]>,
+    /// RFC 6066 Maximum Fragment Length the server will emit.
+    /// Defaults to [MaxFragLen::None] (no cap; unchanged behavior).
+    /// See [MaxFragLen] - this caps ApplicationData record payload, not
+    /// handshake buffers, and does not force clients to send smaller records.
+    pub max_frag_len: MaxFragLen,
 }
 
 impl<'a> ServerSessionConfig<'a> {
@@ -128,6 +190,7 @@ impl<'a> ServerSessionConfig<'a> {
             auth_mode: AuthMode::None,
             min_version: TlsVersion::Tls1_2,
             alpn_protocols: None,
+            max_frag_len: MaxFragLen::None,
         }
     }
 }
@@ -166,6 +229,13 @@ impl<'a> SessionConfig<'a> {
         match self {
             SessionConfig::Client(ClientSessionConfig { min_version, .. }) => *min_version,
             SessionConfig::Server(ServerSessionConfig { min_version, .. }) => *min_version,
+        }
+    }
+
+    fn max_frag_len(&self) -> MaxFragLen {
+        match self {
+            SessionConfig::Client(ClientSessionConfig { max_frag_len, .. }) => *max_frag_len,
+            SessionConfig::Server(ServerSessionConfig { max_frag_len, .. }) => *max_frag_len,
         }
     }
 
@@ -278,6 +348,10 @@ impl<'a> SessionState<'a> {
         unsafe {
             mbedtls_ssl_conf_authmode(&mut *ssl_config, conf.auth_mode().mbedtls_authmode());
         }
+
+        merr!(unsafe {
+            mbedtls_ssl_conf_max_frag_len(&mut *ssl_config, conf.max_frag_len().mfl_code())
+        })?;
 
         if let Some(creds) = conf.creds() {
             merr!(unsafe {


### PR DESCRIPTION
## What

Exposes RFC 6066 **Max Fragment Length (MFL)** as a standard TLS configuration knob. Adds a `MaxFragLen` enum and a `max_frag_len` field to both `ClientSessionConfig` and `ServerSessionConfig`, applied once in `SessionState::new` via `mbedtls_ssl_conf_max_frag_len`.

```rust
let conf = ClientSessionConfig {
    server_name,
    max_frag_len: MaxFragLen::B2048, // cap ApplicationData record payload at 2048 bytes
    ..ClientSessionConfig::new()
};
```

## What it does (and does NOT do)

MFL caps the **ApplicationData record plaintext payload** this endpoint emits:
- **Client:** the value is advertised to the server during the handshake and caps what the client emits.
- **Server:** the value caps what the server emits (normally in response to a client's negotiated value).

Per the MbedTLS C source (`ssl.h`):

> With TLS, this currently only affects ApplicationData (sent with `mbedtls_ssl_read()`), not handshake messages.

So, importantly, MFL:
- does **not** reduce the buffer needed to receive a server `Certificate` or any other handshake message;
- is **not** a substitute for the `ssl-in-content-len-*` / `ssl-out-content-len-*` features (#144) when sizing buffers for the handshake. To actually shrink the record buffers, use those features.
- is a **TLS 1.2 / RFC 6066** mechanism with no effect on TLS 1.3 (which uses `record_size_limit`, RFC 8449, not exposed here).

This is deliberately a separate concern from #144: #144 sizes the record buffers; this caps the ApplicationData record payload.

## Behavior / compatibility

- **No behavior change by default.** `MaxFragLen::None` (the default in both `new()` constructors) maps to MbedTLS code `0`, a no-op. Existing consumers are unaffected.
- **No rebuild forced.** `mbedtls_ssl_conf_max_frag_len` and the `MBEDTLS_SSL_MAX_FRAG_LEN_*` constants are already in the committed bindings (`SSL_MAX_FRAGMENT_LENGTH` is compiled into the prebuilt libraries), so this needs no bindgen change, no new feature, and no on-the-fly MbedTLS rebuild.
- **Useful safety check.** MbedTLS rejects an MFL length greater than `min(IN_CONTENT_LEN, OUT_CONTENT_LEN)` with `BAD_INPUT_DATA`; the call is wrapped in `merr!(...)?`, so an MFL larger than the compiled-in buffers surfaces as an init error rather than silently misbehaving.
- Adding a defaulted public field to the (non-`#[non_exhaustive]`) config structs is non-breaking for in-tree call sites, which construct via `..ClientSessionConfig::new()` / `..ServerSessionConfig::new(...)`. A downstream struct literal that omits `..` would need to add the field (acceptable pre-1.0).

## Testing

- `cargo build -p mbedtls-rs --target riscv32imc-unknown-none-elf` (default features): compiles clean, no warnings, prebuilt libraries reused (no MFL-induced rebuild).
- `cargo +nightly build --no-default-features --features esp32c3 --target riscv32imc-unknown-none-elf` for `examples/esp`: all example binaries compile and link on the MCU target with the new field present.
- Runtime fragmentation behavior (a peer honoring the negotiated MFL) is not asserted here, as it requires a real MFL-honoring network peer; the documented contract describes the runtime behavior.
