### PR TITLE
Fix reachable panics in the ESP exp_mod hook

### DIFF
--- a/mbedtls-rs-sys/Cargo.toml
+++ b/mbedtls-rs-sys/Cargo.toml
@@ -13,6 +13,15 @@ exclude = ["*.pyc", "mbedtls/framework", "mbedtls/programs", "mbedtls/tests"]
 [lib]
 harness = false
 
+# Host-only routing test (F-01). Gated on the internal `_route-test` feature so
+# the default `cargo test` (no `crypto-bigint`) skips this target entirely.
+# `harness = true` is the integration-test default and set here only for clarity
+# (the `[lib] harness = false` above governs the lib target, not `tests/`).
+[[test]]
+name = "exp_mod_route"
+required-features = ["_route-test"]
+harness = true
+
 [features]
 # The default profile is the full config (`tls`), so behavior is unchanged for
 # existing consumers and the pre-generated bindings/libs apply as-is. Select a
@@ -82,6 +91,12 @@ esp32c6 = ["esp-hal/esp32c6", "crypto-bigint", "time"]
 esp32h2 = ["esp-hal/esp32h2", "crypto-bigint", "time"]
 esp32s2 = ["esp-hal/esp32s2", "crypto-bigint", "time"]
 esp32s3 = ["esp-hal/esp32s3", "crypto-bigint", "time"]
+
+# Internal: host-only testing of the ESP exp_mod routing logic. Pulls in
+# `crypto-bigint` (for the operand-size limb constants) WITHOUT `esp-hal`, so
+# `backend::esp_exp_mod_route` and its integration test compile on the host.
+# Not for downstream use.
+_route-test = ["crypto-bigint"]
 
 # ---------------------------------------------------------------------------
 # Features controlling what MbedTLS algorithms gets compiled in.

--- a/mbedtls-rs-sys/src/hook/backend.rs
+++ b/mbedtls-rs-sys/src/hook/backend.rs
@@ -2,5 +2,12 @@
 pub mod embassy;
 #[cfg(feature = "esp-hal")]
 pub mod esp;
+#[cfg(all(not(feature = "esp-hal"), feature = "_route-test"))]
+pub mod esp_exp_mod_route;
+#[cfg(all(
+    feature = "esp-hal",
+    not(any(feature = "esp32c2", feature = "nohook-exp-mod"))
+))]
+pub(crate) mod esp_exp_mod_route;
 #[cfg(feature = "std")]
 pub mod std;

--- a/mbedtls-rs-sys/src/hook/backend/esp/exp_mod.rs
+++ b/mbedtls-rs-sys/src/hook/backend/esp/exp_mod.rs
@@ -1,7 +1,5 @@
 //! Modular exponentiation using ESP hardware acceleration.
 
-use core::ffi::c_int;
-
 #[cfg(not(any(
     feature = "esp32c3",
     feature = "esp32c5",
@@ -14,35 +12,13 @@ use crypto_bigint::{U1024, U2048, U512};
 use crypto_bigint::{U256, U384};
 use esp_hal::rsa::{operand_sizes, RsaContext};
 
+use crate::hook::backend::esp_exp_mod_route::{HwKind, Route};
 use crate::hook::exp_mod::MbedtlsMpiExpMod;
 use crate::{
-    mbedtls_mpi, mbedtls_mpi_add_mpi, mbedtls_mpi_cmp_int, mbedtls_mpi_exp_mod_soft,
-    mbedtls_mpi_free, mbedtls_mpi_grow, mbedtls_mpi_init, mbedtls_mpi_lset, mbedtls_mpi_mod_mpi,
-    mbedtls_mpi_set_bit, merr, MbedtlsError,
+    mbedtls_mpi, mbedtls_mpi_cmp_int, mbedtls_mpi_exp_mod_soft, mbedtls_mpi_free, mbedtls_mpi_grow,
+    mbedtls_mpi_init, mbedtls_mpi_lset, mbedtls_mpi_mod_mpi, mbedtls_mpi_set_bit, merr,
+    MbedtlsError, MBEDTLS_ERR_MPI_BAD_INPUT_DATA,
 };
-
-#[cfg(not(feature = "esp32"))]
-const SOC_RSA_MIN_BIT_LEN: usize = 256;
-#[cfg(feature = "esp32")]
-const SOC_RSA_MIN_BIT_LEN: usize = 512;
-
-#[cfg(not(any(
-    feature = "esp32c3",
-    feature = "esp32c5",
-    feature = "esp32c6",
-    feature = "esp32h2"
-)))]
-const SOC_RSA_MAX_BIT_LEN: usize = 4096;
-#[cfg(any(
-    feature = "esp32c3",
-    feature = "esp32c5",
-    feature = "esp32c6",
-    feature = "esp32h2"
-))]
-const SOC_RSA_MAX_BIT_LEN: usize = 3072;
-
-// Bad input parameters to function.
-// TODO const MBEDTLS_ERR_MPI_BAD_INPUT_DATA: c_int = -0x0004;
 
 macro_rules! modular_exponentiate {
     ($op:ty, $x:expr, $y:expr, $m:expr, $rinv:expr, $z:expr, $x_words:expr, $y_words:expr, $m_words:expr, $op_size:expr) => {{
@@ -82,6 +58,33 @@ macro_rules! modular_exponentiate {
     }};
 }
 
+/// RAII wrapper that frees a locally-owned `mbedtls_mpi` on drop.
+///
+/// Modular exponentiation allocates temporary big integers via the raw
+/// `mbedtls_mpi_*` C API, which has no Rust ownership. Wrapping each temporary
+/// in an `MpiGuard` ensures every early `?` return frees it instead of leaking.
+/// Only locally-initialized temporaries are wrapped; a caller-owned `prec_rr`
+/// must never be placed in a guard.
+struct MpiGuard(mbedtls_mpi);
+
+impl MpiGuard {
+    fn new() -> Self {
+        let mut mpi = mbedtls_mpi {
+            private_s: 0,
+            private_n: 0,
+            private_p: core::ptr::null_mut(),
+        };
+        unsafe { mbedtls_mpi_init(&mut mpi) };
+        Self(mpi)
+    }
+}
+
+impl Drop for MpiGuard {
+    fn drop(&mut self) {
+        unsafe { mbedtls_mpi_free(&mut self.0) };
+    }
+}
+
 /// Modular exponentiation using ESP hardware acceleration.
 pub struct EspExpMod(());
 
@@ -95,6 +98,28 @@ impl EspExpMod {
     /// Create a new `EspExpMod` instance.
     pub const fn new() -> Self {
         Self(())
+    }
+
+    /// Fall back to the MbedTLS software implementation `mbedtls_mpi_exp_mod_soft`.
+    fn soft(
+        &self,
+        z: &mut mbedtls_mpi,
+        x: &mbedtls_mpi,
+        y: &mbedtls_mpi,
+        m: &mbedtls_mpi,
+        prec_rr: Option<&mut mbedtls_mpi>,
+    ) -> Result<(), MbedtlsError> {
+        merr!(unsafe {
+            mbedtls_mpi_exp_mod_soft(
+                z,
+                x,
+                y,
+                m,
+                prec_rr.map(|rr| rr as *mut _).unwrap_or_default(),
+            )
+        })?;
+
+        Ok(())
     }
 
     /// Calculate the number of words used for a hardware operation.
@@ -120,23 +145,17 @@ impl EspExpMod {
     /// so caller should cache the result where possible.
     ///
     /// DO NOT call this function while holding esp_mpi_enable_hardware_hw_op().
-    fn calculate_rinv(prec_rr: &mut mbedtls_mpi, m: &mbedtls_mpi, num_words: usize) -> c_int {
-        let mut rr = mbedtls_mpi {
-            private_s: 0,
-            private_n: 0,
-            private_p: core::ptr::null_mut(),
-        };
+    fn calculate_rinv(
+        prec_rr: &mut mbedtls_mpi,
+        m: &mbedtls_mpi,
+        num_words: usize,
+    ) -> Result<(), MbedtlsError> {
+        let mut rr = MpiGuard::new();
 
-        unsafe { mbedtls_mpi_init(&mut rr) };
+        merr!(unsafe { mbedtls_mpi_set_bit(&mut rr.0, num_words * 32 * 2, 1) })?;
+        merr!(unsafe { mbedtls_mpi_mod_mpi(prec_rr, &rr.0, m) })?;
 
-        unwrap!(merr!(unsafe {
-            mbedtls_mpi_set_bit(&mut rr, num_words * 32 * 2, 1)
-        }));
-        unwrap!(merr!(unsafe { mbedtls_mpi_mod_mpi(prec_rr, &rr, m) }));
-
-        unsafe { mbedtls_mpi_free(&mut rr) };
-
-        0
+        Ok(())
     }
 }
 
@@ -149,71 +168,70 @@ impl MbedtlsMpiExpMod for EspExpMod {
         m: &mbedtls_mpi,
         mut prec_rr: Option<&mut mbedtls_mpi>,
     ) -> Result<(), MbedtlsError> {
+        // Reject null / internally-inconsistent operands before any limb read.
+        // `mpi_words` dereferences `private_p`, so a non-null `private_p` must
+        // back any non-zero `private_n`, and the modulus must be present.
+        if m.private_p.is_null() || m.private_n == 0 {
+            return Err(MbedtlsError::new(MBEDTLS_ERR_MPI_BAD_INPUT_DATA));
+        }
+        if (x.private_n > 0 && x.private_p.is_null()) || (y.private_n > 0 && y.private_p.is_null())
+        {
+            return Err(MbedtlsError::new(MBEDTLS_ERR_MPI_BAD_INPUT_DATA));
+        }
+
+        // Modulus must be positive and odd; exponent must be non-negative.
+        if unsafe { mbedtls_mpi_cmp_int(m, 0) } <= 0 || unsafe { m.private_p.read() } & 1 == 0 {
+            return Err(MbedtlsError::new(MBEDTLS_ERR_MPI_BAD_INPUT_DATA));
+        }
+        if unsafe { mbedtls_mpi_cmp_int(y, 0) } < 0 {
+            return Err(MbedtlsError::new(MBEDTLS_ERR_MPI_BAD_INPUT_DATA));
+        }
+
+        // X^0 mod M == 1 for any (valid) M; nothing more to compute.
+        if unsafe { mbedtls_mpi_cmp_int(y, 0) } == 0 {
+            merr!(unsafe { mbedtls_mpi_lset(z, 1) })?;
+            return Ok(());
+        }
+
+        // The hardware path has no sign handling and yields a non-negative
+        // result; a negative base needs the software path's sign semantics.
+        if x.private_s == -1 {
+            return self.soft(z, x, y, m, prec_rr);
+        }
+
         let x_words = mpi_words(x);
         let y_words = mpi_words(y);
         let m_words = mpi_words(m);
 
-        // All numbers must be the lame length, so choose longest number as
-        // cardinal length of operation
+        // All operands share the cardinal length: the longest of the three.
         let num_words = Self::calculate_hw_words(m_words.max(x_words.max(y_words)));
 
-        if num_words * 32 < SOC_RSA_MIN_BIT_LEN || num_words * 32 > SOC_RSA_MAX_BIT_LEN {
-            unwrap!(merr!(unsafe {
-                mbedtls_mpi_exp_mod_soft(
-                    z,
-                    x,
-                    y,
-                    m,
-                    prec_rr.as_mut().map(|rr| *rr as *mut _).unwrap_or_default(),
-                )
-            }));
-
-            return Ok(());
-        }
-
-        if m.private_p.is_null() {
-            todo!("Handle this null");
-        }
-
-        unsafe {
-            if mbedtls_mpi_cmp_int(m, 0) <= 0 || m.private_p.read() & 1 == 0 {
-                panic!(); // TODO
-                          // return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
-            }
-
-            if mbedtls_mpi_cmp_int(y, 0) < 0 {
-                panic!(); // TODO
-                          // return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
-            }
-
-            if mbedtls_mpi_cmp_int(y, 0) == 0 {
-                mbedtls_mpi_lset(z, 1);
-            }
-        }
-
-        let mut rinv_new = mbedtls_mpi {
-            private_s: 0,
-            private_n: 0,
-            private_p: core::ptr::null_mut(),
+        // Decide the route BEFORE allocating Rinv, so an unsupported size falls
+        // back to software without leaving a borrowed `prec_rr` / allocated
+        // temporary to clean up.
+        let kind = match Route::route_for(num_words) {
+            Route::Soft => return self.soft(z, x, y, m, prec_rr),
+            Route::Hw(kind) => kind,
         };
+
+        let mut rinv_new = MpiGuard::new();
 
         // Determine rinv, either `prec_rr` for cached value or the local `rinv_new`
         let rinv: &mut mbedtls_mpi = if let Some(prec_rr) = prec_rr.as_mut() {
             prec_rr
         } else {
-            unsafe { mbedtls_mpi_init(&mut rinv_new) };
-            &mut rinv_new
+            &mut rinv_new.0
         };
 
         if rinv.private_p.is_null() {
-            Self::calculate_rinv(rinv, m, num_words);
+            Self::calculate_rinv(rinv, m, num_words)?;
         }
 
-        unwrap!(merr!(unsafe { mbedtls_mpi_grow(z, m_words) }));
+        merr!(unsafe { mbedtls_mpi_grow(z, m_words) })?;
 
-        match num_words {
+        match kind {
             #[cfg(not(feature = "esp32"))]
-            U256::LIMBS => modular_exponentiate!(
+            HwKind::Op256 => modular_exponentiate!(
                 operand_sizes::Op256,
                 x,
                 y,
@@ -226,7 +244,7 @@ impl MbedtlsMpiExpMod for EspExpMod {
                 U256::LIMBS
             ),
             #[cfg(not(feature = "esp32"))]
-            U384::LIMBS => modular_exponentiate!(
+            HwKind::Op384 => modular_exponentiate!(
                 operand_sizes::Op384,
                 x,
                 y,
@@ -238,7 +256,7 @@ impl MbedtlsMpiExpMod for EspExpMod {
                 m_words,
                 U384::LIMBS
             ),
-            U512::LIMBS => modular_exponentiate!(
+            HwKind::Op512 => modular_exponentiate!(
                 operand_sizes::Op512,
                 x,
                 y,
@@ -250,7 +268,7 @@ impl MbedtlsMpiExpMod for EspExpMod {
                 m_words,
                 U512::LIMBS
             ),
-            U1024::LIMBS => modular_exponentiate!(
+            HwKind::Op1024 => modular_exponentiate!(
                 operand_sizes::Op1024,
                 x,
                 y,
@@ -262,7 +280,7 @@ impl MbedtlsMpiExpMod for EspExpMod {
                 m_words,
                 U1024::LIMBS
             ),
-            U2048::LIMBS => modular_exponentiate!(
+            HwKind::Op2048 => modular_exponentiate!(
                 operand_sizes::Op2048,
                 x,
                 y,
@@ -280,7 +298,7 @@ impl MbedtlsMpiExpMod for EspExpMod {
                 feature = "esp32c6",
                 feature = "esp32h2"
             )))]
-            U4096::LIMBS => modular_exponentiate!(
+            HwKind::Op4096 => modular_exponentiate!(
                 operand_sizes::Op4096,
                 x,
                 y,
@@ -292,22 +310,10 @@ impl MbedtlsMpiExpMod for EspExpMod {
                 m_words,
                 U4096::LIMBS
             ),
-            _ => unreachable!(),
         }
 
-        assert_eq!(x.private_s, 1);
-
-        // Compensate for negative X
-        if x.private_s == -1 && unsafe { y.private_p.read() & 1 } != 0 {
-            z.private_s = -1;
-            unwrap!(merr!(unsafe { mbedtls_mpi_add_mpi(z, m, z) }));
-        } else {
-            z.private_s = 1;
-        }
-
-        if prec_rr.is_none() {
-            unsafe { mbedtls_mpi_free(&mut rinv_new) };
-        }
+        // Non-negative base, so the result is positive (sign-magnitude).
+        z.private_s = 1;
 
         Ok(())
     }

--- a/mbedtls-rs-sys/src/hook/backend/esp_exp_mod_route.rs
+++ b/mbedtls-rs-sys/src/hook/backend/esp_exp_mod_route.rs
@@ -1,0 +1,88 @@
+//! Pure routing decision for ESP modular-exponentiation: pick the hardware
+//! operand size for a given limb count, or fall back to software.
+//!
+//! This is intentionally free of any `esp_hal` dependency so it can be unit
+//! tested on the host. The production ESP backend in
+//! [`super::esp::exp_mod`](super::esp::exp_mod) calls [`Route::route_for`] to
+//! decide whether a request can be served by the RSA peripheral or must use the
+//! MbedTLS software path. Keeping it here (rather than inline in the
+//! `esp_hal`-gated module) is what makes the routing logic testable without an
+//! ESP target.
+
+use crypto_bigint::U1024;
+use crypto_bigint::U2048;
+#[cfg(not(feature = "esp32"))]
+use crypto_bigint::U256;
+#[cfg(not(feature = "esp32"))]
+use crypto_bigint::U384;
+#[cfg(not(any(
+    feature = "esp32c3",
+    feature = "esp32c5",
+    feature = "esp32c6",
+    feature = "esp32h2"
+)))]
+use crypto_bigint::U4096;
+use crypto_bigint::U512;
+
+/// A hardware-supported RSA operand size, identified by its limb count.
+///
+/// Each variant corresponds 1:1 to an `esp_hal::rsa::operand_sizes::OpN` and is
+/// gated by exactly the same chip features as the hardware path, so a variant
+/// only exists when the peripheral on that chip can serve it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HwKind {
+    #[cfg(not(feature = "esp32"))]
+    Op256,
+    #[cfg(not(feature = "esp32"))]
+    Op384,
+    Op512,
+    Op1024,
+    Op2048,
+    #[cfg(not(any(
+        feature = "esp32c3",
+        feature = "esp32c5",
+        feature = "esp32c6",
+        feature = "esp32h2"
+    )))]
+    Op4096,
+}
+
+/// Where a modular-exponentiation request of a given size should be dispatched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Route {
+    /// No hardware operand size matches: use the MbedTLS software path.
+    Soft,
+    /// Serve with the RSA peripheral at this operand size.
+    Hw(HwKind),
+}
+
+impl Route {
+    /// Decide how to serve a modular exponentiation of `num_words` limbs.
+    ///
+    /// `num_words` is counted in word-sized limbs (`crypto_bigint::Limb`); on
+    /// the 32-bit ESP production targets these are the 32-bit `mbedtls_mpi_uint`
+    /// limbs. It is the post-`calculate_hw_words` count (already rounded up to
+    /// the 512-bit block on `esp32`). Any size the peripheral cannot serve,
+    /// including in-range-but-unsupported sizes such as 96 limbs (3072-bit) on a
+    /// chip whose RSA arms stop at 2048, returns [`Route::Soft`] instead of
+    /// panicking.
+    pub fn route_for(num_words: usize) -> Self {
+        match num_words {
+            #[cfg(not(feature = "esp32"))]
+            n if n == U256::LIMBS => Route::Hw(HwKind::Op256),
+            #[cfg(not(feature = "esp32"))]
+            n if n == U384::LIMBS => Route::Hw(HwKind::Op384),
+            n if n == U512::LIMBS => Route::Hw(HwKind::Op512),
+            n if n == U1024::LIMBS => Route::Hw(HwKind::Op1024),
+            n if n == U2048::LIMBS => Route::Hw(HwKind::Op2048),
+            #[cfg(not(any(
+                feature = "esp32c3",
+                feature = "esp32c5",
+                feature = "esp32c6",
+                feature = "esp32h2"
+            )))]
+            n if n == U4096::LIMBS => Route::Hw(HwKind::Op4096),
+            _ => Route::Soft,
+        }
+    }
+}

--- a/mbedtls-rs-sys/tests/exp_mod_route.rs
+++ b/mbedtls-rs-sys/tests/exp_mod_route.rs
@@ -1,0 +1,48 @@
+//! Host tests for the ESP modular-exponentiation routing decision (F-01).
+//!
+//! Built only under the internal `_route-test` feature, which enables
+//! `crypto-bigint` without `esp-hal`, so this runs on the host. It exercises
+//! the same `Route::route_for` that the production ESP backend calls, proving
+//! that operand sizes the hardware cannot serve route to software instead of
+//! panicking - the bug behind F-01.
+//!
+//! Sizes are expressed relative to `UN::LIMBS` rather than as raw limb counts:
+//! `crypto-bigint`'s limb is word-sized (`u64` on a 64-bit host, `u32` on the
+//! 32-bit ESP targets), so a fixed integer would denote different bit-widths on
+//! host versus target. Deriving from `LIMBS` keeps the assertions meaningful on
+//! any word size.
+
+use crypto_bigint::{U1024, U2048, U256, U384, U4096, U512};
+
+use mbedtls_rs_sys::hook::backend::esp_exp_mod_route::{HwKind, Route};
+
+#[test]
+fn supported_sizes_route_to_hardware() {
+    assert_eq!(Route::route_for(U256::LIMBS), Route::Hw(HwKind::Op256));
+    assert_eq!(Route::route_for(U384::LIMBS), Route::Hw(HwKind::Op384));
+    assert_eq!(Route::route_for(U512::LIMBS), Route::Hw(HwKind::Op512));
+    assert_eq!(Route::route_for(U1024::LIMBS), Route::Hw(HwKind::Op1024));
+    assert_eq!(Route::route_for(U2048::LIMBS), Route::Hw(HwKind::Op2048));
+    assert_eq!(Route::route_for(U4096::LIMBS), Route::Hw(HwKind::Op4096));
+}
+
+#[test]
+fn in_range_unsupported_sizes_route_to_software() {
+    // A limb count strictly between two supported operand sizes matches no arm.
+    // On the 32-bit ESP targets U2048::LIMBS + 1 is 65 limbs (2080-bit); the
+    // 3072-bit (96-limb) case that used to hit `unreachable!()` is one instance
+    // of this class.
+    assert_eq!(Route::route_for(U2048::LIMBS + 1), Route::Soft);
+    assert_eq!(Route::route_for(U1024::LIMBS + 1), Route::Soft);
+    assert_eq!(Route::route_for(U512::LIMBS + 1), Route::Soft);
+}
+
+#[test]
+fn out_of_range_sizes_route_to_software() {
+    // Below the smallest supported size.
+    assert_eq!(Route::route_for(0), Route::Soft);
+    assert_eq!(Route::route_for(U256::LIMBS - 1), Route::Soft);
+    // Above the largest supported size.
+    assert_eq!(Route::route_for(U4096::LIMBS + 1), Route::Soft);
+    assert_eq!(Route::route_for(U4096::LIMBS * 2), Route::Soft);
+}


### PR DESCRIPTION
## What

Fixes a reachable abort cluster in the ESP hardware modular-exponentiation hook, `EspExpMod::exp_mod` (the backend for `mbedtls_mpi_exp_mod`, covering RSA and finite-field DH).

The hook panicked instead of returning an error on several inputs. The most serious is reachable from negotiated handshake parameters: a **3072-bit modulus (96 limbs)** passes the size guard but matches no hardware operand-size arm and hits `unreachable!()` -> abort. `ffdhe3072` and DHE-RSA are compiled into the default config, so a peer (or selected ciphersuite) can drive this. Other inputs aborted via `todo!()`, `panic!()`, `unwrap!()`, and `assert_eq!()`.

## How

The C-ABI shim `mbedtls_mpi_exp_mod` already maps a Rust `Err` to a negative MbedTLS code, so the fix makes the hook **return errors / fall back to software** rather than abort:

- **Routing extracted to a testable module.** A new `esp_hal`-free `backend::esp_exp_mod_route` decides, from the operand limb count, whether the RSA peripheral can serve a request (`Route::Hw(HwKind)`) or it must use software (`Route::Soft`). The hardware `match` now dispatches on `HwKind` and is exhaustive: there is no `unreachable!()`, and any operand size the peripheral cannot serve (including 1536/2560/3072/3584-bit) falls back to `mbedtls_mpi_exp_mod_soft`.
- **Operands validated before any limb dereference.** A null or non-positive/even modulus, a negative exponent, and null/internally-inconsistent MPIs now return `MBEDTLS_ERR_MPI_BAD_INPUT_DATA` instead of panicking.
- **Negative base routed to software** (which implements the sign semantics the old hardware compensation branch intended). This also removes an `assert_eq!(x.private_s, 1)` that panicked on a negative base and made the sign-compensation branch below it dead code.
- **`unwrap!(merr!(...))` replaced with `merr!(...)?`**, and temporary MPIs are wrapped in a small RAII guard so early returns free them.

Behavior for valid hardware operand sizes (256/512/1024/2048-bit, plus 384/4096-bit where the chip supports them) is unchanged.

## Testing

- **Host integration test** (`tests/exp_mod_route.rs`) exercises the production `hw_route` and asserts that supported sizes route to hardware and unsupported sizes - including the 3072-bit class behind this bug - route to software. The internal `_route-test` feature enables `crypto-bigint` without `esp-hal` so the pure routing logic builds and runs on the host. `cargo test -p mbedtls-rs-sys --features _route-test,tls --test exp_mod_route` -> 3 passed.
- **ESP target build:** `cargo +nightly build -p mbedtls-rs-sys --features esp32c3,tls --target riscv32imc-unknown-none-elf -Zbuild-std=core,alloc` builds clean (the riscv `Op512`/`Op1024`/`Op2048` arms).
- A static scan confirms no `todo!`/`panic!`/`unreachable!`/`unwrap!`/`assert!` remain in `esp/exp_mod.rs`; clippy is clean on the lib and the test target.

## Notes

- The Xtensa operand arms (`Op256`/`Op384`/`Op4096`, on `esp32`/`esp32s2`/`esp32s3`) are covered by the host routing test, and CI builds them on those targets; I could not build them locally (no `esp` Rust toolchain available), so the host test was my local proxy for that path.
- `prec_rr` reuse still relies on the existing MbedTLS contract that a non-null cached value is valid for the same modulus; this PR does not change that contract.
- This is one of a few fixes coming out of a wider review of the hooks and async TLS paths; I expect to open the next PR (the async SSL-context aliasing fix) in the next few days.