### PR TITLE
Fix aliasing UB in the async SSL context and serialize split halves

### DIFF
--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -316,6 +316,18 @@ where
     fn as_mut(&mut self) -> &mut T {
         unsafe { self.0.as_mut() }
     }
+
+    /// Get the raw pointer to the inner value.
+    ///
+    /// The pointer is the original allocation pointer preserved in the
+    /// `NonNull` (not derived from a Rust reference), so writing through it
+    /// (e.g. by C code via FFI) is sound. Taking `&mut self` ensures the caller
+    /// is not simultaneously holding a shared reference to the same object via
+    /// `Deref`. Used by the async session path, which must hand MbedTLS a `*mut`
+    /// it can write through.
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_ptr()
+    }
 }
 
 impl<T> Deref for MBox<T>

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -1,6 +1,7 @@
 use core::ffi::{c_int, c_uchar, c_void, CStr};
 use core::future::{poll_fn, Future};
 use core::pin::pin;
+use core::ptr::NonNull;
 use core::task::{Context, Poll};
 
 use embedded_io::ErrorKind;
@@ -175,17 +176,21 @@ where
 
         let (read, write) = self.stream.split();
 
+        // Derive one write-provenance pointer from a unique borrow of the owning
+        // MBox; both halves use it to drive the same context.
+        let ssl_context = unsafe { NonNull::new_unchecked(self.state.ssl_context.as_mut_ptr()) };
+
         Ok((
             SessionRead {
                 stream: NoWrite(read),
-                ssl_context: &self.state.ssl_context,
+                ssl_context,
                 eof: &mut self.eof,
                 read_byte: &mut self.read_byte,
                 write_byte: None,
             },
             SessionWrite {
                 stream: NoRead(write),
-                ssl_context: &self.state.ssl_context,
+                ssl_context,
                 eof: false,
                 read_byte: None,
                 write_byte: &mut self.write_byte,
@@ -357,8 +362,8 @@ where
 {
     /// The underlying stream
     stream: NoWrite<T>,
-    /// The MbedTLS SSL context
-    ssl_context: &'a mbedtls_ssl_context,
+    /// The MbedTLS SSL context (write-provenance pointer; see `MBio`).
+    ssl_context: NonNull<mbedtls_ssl_context>,
     /// Whether we had received a close notify from the peer
     eof: &'a mut bool,
     /// A state necessary so as to implement `MBio::wait_readable`
@@ -404,8 +409,8 @@ where
 {
     /// The underlying stream
     stream: NoRead<T>,
-    /// The MbedTLS SSL context
-    ssl_context: &'a mbedtls_ssl_context,
+    /// The MbedTLS SSL context (write-provenance pointer; see `MBio`).
+    ssl_context: NonNull<mbedtls_ssl_context>,
     /// A dummy value, as we don't need to track EOF in the write half
     eof: bool,
     /// A state necessary so as to implement `MBio::wait_readable`
@@ -488,8 +493,12 @@ where
 struct MBio<'a, T> {
     /// The underlying stream
     stream: T,
-    /// The MbedTLS SSL context
-    ssl_context: &'a mbedtls_ssl_context,
+    /// The MbedTLS SSL context, held as a write-provenance pointer so MbedTLS
+    /// can write through it via FFI. Must be derived from a unique borrow of
+    /// the owning context, never from a shared reference. The `'a` lifetime is
+    /// pinned by the `&'a mut` fields below, so the pointer cannot outlive the
+    /// `Session` that owns the context.
+    ssl_context: NonNull<mbedtls_ssl_context>,
     /// `true` if we had received a close notify from the peer
     eof: &'a mut bool,
     /// A state necessary so as to implement `MBio::wait_readable`
@@ -503,9 +512,12 @@ where
     T: Read + Write,
 {
     fn from_session(session: &'a mut Session<'_, T>) -> Self {
+        // Derive the context pointer from a unique borrow of the owning MBox so
+        // it carries write provenance.
+        let ssl_context = unsafe { NonNull::new_unchecked(session.state.ssl_context.as_mut_ptr()) };
         Self::new(
             &mut session.stream,
-            &session.state.ssl_context,
+            ssl_context,
             &mut session.eof,
             &mut session.read_byte,
             &mut session.write_byte,
@@ -549,7 +561,7 @@ where
 {
     const fn new(
         stream: T,
-        ssl_context: &'a mbedtls_ssl_context,
+        ssl_context: NonNull<mbedtls_ssl_context>,
         eof: &'a mut bool,
         read_byte: &'a mut Option<u8>,
         write_byte: &'a mut Option<u8>,
@@ -567,22 +579,17 @@ where
     async fn connect(&mut self, saved_session: Option<&SavedSession>) -> Result<(), SessionError> {
         debug!("Establishing SSL connection");
 
-        merr!(unsafe { mbedtls_ssl_session_reset(self.ssl_context as *const _ as *mut _) })?;
+        merr!(unsafe { mbedtls_ssl_session_reset(self.ssl_context.as_ptr()) })?;
 
         if let Some(saved_session) = saved_session {
             merr!(unsafe {
-                mbedtls_ssl_set_session(
-                    self.ssl_context as *const _ as *mut _,
-                    &*saved_session.mbedtls_session,
-                )
+                mbedtls_ssl_set_session(self.ssl_context.as_ptr(), &*saved_session.mbedtls_session)
             })?;
         }
 
         loop {
             match self
-                .call_mbedtls(|ssl_ctx| unsafe {
-                    mbedtls_ssl_handshake(ssl_ctx as *const _ as *mut _)
-                })
+                .call_mbedtls(|ssl_ctx| unsafe { mbedtls_ssl_handshake(ssl_ctx) })
                 .await
             {
                 MBEDTLS_ERR_SSL_WANT_READ => {
@@ -616,11 +623,7 @@ where
         loop {
             match self
                 .call_mbedtls(|ssl_ctx| unsafe {
-                    mbedtls_ssl_read(
-                        ssl_ctx as *const _ as *mut _,
-                        buf.as_mut_ptr() as *mut _,
-                        buf.len() as _,
-                    )
+                    mbedtls_ssl_read(ssl_ctx, buf.as_mut_ptr() as *mut _, buf.len() as _)
                 })
                 .await
             {
@@ -654,11 +657,7 @@ where
         loop {
             match self
                 .call_mbedtls(|ssl_ctx| unsafe {
-                    mbedtls_ssl_write(
-                        ssl_ctx as *const _ as *mut _,
-                        data.as_ptr() as *const _,
-                        data.len() as _,
-                    )
+                    mbedtls_ssl_write(ssl_ctx, data.as_ptr() as *const _, data.len() as _)
                 })
                 .await
             {
@@ -690,7 +689,7 @@ where
     /// Close the TLS connection by sending the "close notify" alert to the peer and flushing the stream
     pub async fn close(&mut self) -> Result<(), SessionError> {
         merr!(
-            self.call_mbedtls(|ssl| unsafe { mbedtls_ssl_close_notify(ssl as *const _ as *mut _) })
+            self.call_mbedtls(|ssl| unsafe { mbedtls_ssl_close_notify(ssl) })
                 .await
         )?;
 
@@ -744,14 +743,16 @@ where
     /// and with a proper context for the async operations on the underlying stream
     async fn call_mbedtls<F>(&mut self, mut f: F) -> i32
     where
-        F: FnMut(&mbedtls_ssl_context) -> i32,
+        F: FnMut(*mut mbedtls_ssl_context) -> i32,
     {
         poll_fn(|ctx| {
             let mut io_ctx = MBioCallCtx { io: self, ctx };
 
+            let ssl_context = io_ctx.io.ssl_context.as_ptr();
+
             unsafe {
                 mbedtls_ssl_set_bio(
-                    io_ctx.io.ssl_context as *const _ as *mut _,
+                    ssl_context,
                     &mut io_ctx as *const _ as *mut MBioCallCtx<'_, '_, '_, T> as *mut c_void,
                     Some(Self::raw_send),
                     Some(Self::raw_receive),
@@ -759,18 +760,12 @@ where
                 );
             }
 
-            let result = f(io_ctx.io.ssl_context);
+            let result = f(ssl_context);
 
             // Remove the callbacks so that we get a warning from MbedTLS in case
             // it needs to invoke them when we don't anticipate so (for bugs detection)
             unsafe {
-                mbedtls_ssl_set_bio(
-                    io_ctx.io.ssl_context as *const _ as *mut _,
-                    core::ptr::null_mut(),
-                    None,
-                    None,
-                    None,
-                );
+                mbedtls_ssl_set_bio(ssl_context, core::ptr::null_mut(), None, None, None);
             }
 
             Poll::Ready(result)

--- a/mbedtls-rs/tests/async_split_aliasing.rs
+++ b/mbedtls-rs/tests/async_split_aliasing.rs
@@ -1,0 +1,98 @@
+//! Standalone aliasing model for the async split-session provenance fix.
+//!
+//! The real `MBio`/`SessionRead`/`SessionWrite` internals are private, and
+//! constructing a real `Session` needs the MbedTLS C library and a live
+//! handshake, so they can't run under miri here. Instead this test re-creates
+//! the exact pointer pattern the fix relies on - a context owned behind a
+//! `NonNull` derived from a unique borrow (mirroring `MBox::as_mut_ptr`), shared
+//! by two halves, with fake "FFI" functions that actually WRITE through the
+//! `*mut` - so `cargo +nightly miri test` can prove the Rust-side provenance is
+//! sound.
+//!
+//! What it validates: writing through a `*mut` whose provenance is a unique
+//! `&mut` (not a shared `&`) is Stacked/Tree-Borrows clean, including when two
+//! halves hold copies of the same pointer (the write-through-shared-ref bug
+//! this fix removes would fail here).
+
+use core::ptr::NonNull;
+
+// --- A stand-in for `mbedtls_ssl_context`: a struct C would mutate.
+struct FakeCtx {
+    counter: u64,
+    last_op: u8,
+}
+
+// --- Fake "FFI": these mutate THROUGH the raw pointer, exactly like MbedTLS C
+// writes through the pointer the real code hands it. A no-op stub would not
+// exercise the write, so these deliberately write.
+unsafe fn fake_ssl_handshake(ctx: *mut FakeCtx) -> i32 {
+    (*ctx).counter += 1;
+    (*ctx).last_op = 1;
+    0
+}
+unsafe fn fake_ssl_read(ctx: *mut FakeCtx) -> i32 {
+    (*ctx).counter += 1;
+    (*ctx).last_op = 2;
+    0
+}
+unsafe fn fake_ssl_write(ctx: *mut FakeCtx) -> i32 {
+    (*ctx).counter += 1;
+    (*ctx).last_op = 3;
+    0
+}
+
+// --- Owner that hands out a write-provenance pointer from a unique borrow,
+// mirroring `MBox::as_mut_ptr(&mut self) -> *mut T`.
+struct Owner {
+    ctx: FakeCtx,
+}
+impl Owner {
+    fn as_mut_ptr(&mut self) -> *mut FakeCtx {
+        &mut self.ctx as *mut FakeCtx
+    }
+}
+
+// --- The two halves, each holding a COPY of the same NonNull (as `split` does).
+struct ReadHalf {
+    ctx: NonNull<FakeCtx>,
+}
+struct WriteHalf {
+    ctx: NonNull<FakeCtx>,
+}
+
+impl ReadHalf {
+    fn read(&mut self) -> i32 {
+        unsafe { fake_ssl_read(self.ctx.as_ptr()) }
+    }
+}
+impl WriteHalf {
+    fn write(&mut self) -> i32 {
+        unsafe { fake_ssl_write(self.ctx.as_ptr()) }
+    }
+}
+
+#[test]
+fn write_through_unique_provenance_pointer_is_sound() {
+    let mut owner = Owner {
+        ctx: FakeCtx {
+            counter: 0,
+            last_op: 0,
+        },
+    };
+
+    // Derive ONE pointer from a unique borrow and share it with both halves,
+    // exactly as `split` does. Under Stacked/Tree Borrows this is only sound
+    // because the pointer carries write provenance from `&mut`, not from `&`.
+    let ctx = unsafe { NonNull::new_unchecked(owner.as_mut_ptr()) };
+    let mut read = ReadHalf { ctx };
+    let mut write = WriteHalf { ctx };
+
+    // Handshake, then a read and a write, each mutating through the pointer.
+    unsafe { fake_ssl_handshake(ctx.as_ptr()) };
+    assert_eq!(read.read(), 0);
+    assert_eq!(write.write(), 0);
+
+    // The fake FFI wrote through the pointer each time (handshake + read + write).
+    assert_eq!(owner.ctx.counter, 3);
+    assert_eq!(owner.ctx.last_op, 3);
+}


### PR DESCRIPTION
## What

Fixes undefined behaviour in the async TLS path: the SSL context was mutated through a shared reference.

`MBio`/`SessionRead`/`SessionWrite` stored the `mbedtls_ssl_context` as a shared `&mbedtls_ssl_context` and then cast it to `*mut` (`as *const _ as *mut _`) so MbedTLS could write through it. Writing through a pointer whose provenance is a shared reference is UB under Stacked/Tree Borrows, and `mbedtls_ssl_context` is not behind an `UnsafeCell`. This applied to every async handshake/read/write/close, not just to a split session. (The blocking path already did the right thing with `&mut *`.)

## How

- `MBio`, `SessionRead`, and `SessionWrite` now hold a `NonNull<mbedtls_ssl_context>` derived from a unique borrow of the owning allocation (a new `MBox::as_mut_ptr`), and the FFI is handed a `*mut` directly.
- `call_mbedtls`'s callback signature becomes `FnMut(*mut mbedtls_ssl_context)`.
- Every `&T as *mut T` cast in the async path is removed.
- The read-only accessors (`tls_verification_details`, `tls_alpn`, `save`) keep using shared references to the const MbedTLS functions.

The public API is unchanged, and there is no new dependency or `mbedtls-rs-sys` change.

## Scope note

An earlier version of this PR also tried to serialize the two halves of `Session::split` with an async lock. That was wrong - it deadlocks request/response protocols (a read parked on `WANT_READ` holds the lock, so a write that the peer is waiting for can never proceed), and a per-call lock wouldn't help because these futures are `!Send`/single-threaded and each `mbedtls_ssl_*` call is already synchronous within one poll. That serialization has been removed, so this PR is now **only** the provenance fix.

Making `split` genuinely safe for full duplex is a larger, separate change: MbedTLS `ssl_read` and `ssl_write` share output/continuation state on one context (a read can emit alerts / renegotiation / post-handshake records, and `ssl_read` can return `WANT_WRITE` while `ssl_write` can return `WANT_READ`), so a correct split needs a driver that owns the context and both transport directions rather than two halves driving the context independently. I'd like to do that as a follow-up.

## Testing

The real `MBio`/`SessionRead`/`SessionWrite` internals are private and constructing a real `Session` needs the MbedTLS C library and a live handshake, so the soundness can't be exercised against the real types under Miri here. A host test (`tests/async_split_aliasing.rs`) instead models the exact pointer pattern in isolation - a context owned behind a `NonNull` derived from a unique borrow, shared by two halves, with fake "FFI" functions that actually write through the `*mut`:

```
MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p mbedtls-rs --test async_split_aliasing
```

passes under Tree Borrows. (As a check, temporarily reintroducing the old shared-reference cast in that model makes Miri flag it - "the accessed tag has state Frozen which forbids this child write access" - so the model detects the exact bug this PR removes.)

Also verified: `cargo build`/`clippy`/`fmt --check` on `mbedtls-rs`, and the esp32c3 and esp32c2 example builds.