### PR TITLE
Fix aliasing UB in the cert/key constructors via unique-borrow provenance

### DIFF
--- a/mbedtls-rs/src/cert.rs
+++ b/mbedtls-rs/src/cert.rs
@@ -43,18 +43,19 @@ impl Certificate<'static> {
     /// This will return an error if an error occurs during parsing such as passing a DER encoded
     /// certificate in a PEM format, and vice-versa.
     pub fn new(x509: X509<'_>) -> Result<Self, MbedtlsError> {
-        let crt = MRc::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_X509_ALLOC_FAILED))?;
+        let mut crt: MRc<mbedtls_x509_crt> =
+            MRc::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_X509_ALLOC_FAILED))?;
 
         match x509 {
             X509::PEM(str) => merr!(unsafe {
                 mbedtls_x509_crt_parse(
-                    &*crt as *const _ as *mut _,
+                    crt.as_mut_ptr(),
                     str.as_ptr() as *const _,
                     str.count_bytes() + 1,
                 )
             }),
             X509::DER(bytes) => merr!(unsafe {
-                mbedtls_x509_crt_parse_der(&*crt as *const _ as *mut _, bytes.as_ptr(), bytes.len())
+                mbedtls_x509_crt_parse_der(crt.as_mut_ptr(), bytes.as_ptr(), bytes.len())
             }),
         }?;
 
@@ -79,14 +80,11 @@ impl<'d> Certificate<'d> {
     /// This will return an error if an error occurs during parsing.
     /// [TlsError::InvalidFormat] will be returned if a PEM encoded certificate is passed.
     pub fn new_no_copy(x509_der: &'d [u8]) -> Result<Self, SessionError> {
-        let crt = MRc::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_X509_ALLOC_FAILED))?;
+        let mut crt: MRc<mbedtls_x509_crt> =
+            MRc::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_X509_ALLOC_FAILED))?;
 
         merr!(unsafe {
-            mbedtls_x509_crt_parse_der_nocopy(
-                &*crt as *const _ as *mut _,
-                x509_der.as_ptr(),
-                x509_der.len(),
-            )
+            mbedtls_x509_crt_parse_der_nocopy(crt.as_mut_ptr(), x509_der.as_ptr(), x509_der.len())
         })?;
 
         Ok(Self {
@@ -114,7 +112,8 @@ impl PrivateKey {
     /// This will return an error if an error occurs during parsing such as passing a DER encoded
     /// private key in a PEM format, and vice-versa.
     pub fn new(x509: X509<'_>, password: Option<&str>) -> Result<Self, SessionError> {
-        let pk = MRc::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_PK_ALLOC_FAILED))?;
+        let mut pk: MRc<mbedtls_pk_context> =
+            MRc::new().ok_or(MbedtlsError::new(MBEDTLS_ERR_PK_ALLOC_FAILED))?;
 
         #[allow(clippy::unnecessary_cast)]
         let (ptr, len) = match x509 {
@@ -130,7 +129,7 @@ impl PrivateKey {
 
         merr!(unsafe {
             mbedtls_pk_parse_key(
-                &*pk as *const _ as *mut _,
+                pk.as_mut_ptr(),
                 ptr as _,
                 len,
                 password_ptr,

--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -392,6 +392,26 @@ where
     fn as_ref(&self) -> &T {
         &unsafe { self.0.as_ref() }.0
     }
+
+    /// Get a raw pointer to the inner value, with write provenance.
+    ///
+    /// The pointer is projected from the original `(T, usize)` allocation
+    /// pointer in the `NonNull` (not derived from a Rust reference), so writing
+    /// through it (e.g. by C code via FFI) is sound. `addr_of_mut!` projects the
+    /// `.0` field without ever forming an intermediate reference, and must be
+    /// used rather than `self.0.as_ptr().cast::<T>()` because the field order of
+    /// the `(T, usize)` tuple is not guaranteed.
+    ///
+    /// SAFETY: unlike `MBox`, `MRc` is `Clone`, so `&mut self` alone does not
+    /// guarantee unique access to the inner `T` (a clone could be reading it).
+    /// The caller must ensure no other live reference to the inner `T` exists
+    /// for the duration of the write. This holds at construction, where the
+    /// `MRc` is freshly allocated, has refcount 1 and has not yet been cloned -
+    /// which is the only context this is used in. Writing through this pointer
+    /// while a clone concurrently dereferences the value would be UB.
+    fn as_mut_ptr(&mut self) -> *mut T {
+        unsafe { core::ptr::addr_of_mut!((*self.0.as_ptr()).0) }
+    }
 }
 
 impl<T> Clone for MRc<T>

--- a/mbedtls-rs/src/session/blocking.rs
+++ b/mbedtls-rs/src/session/blocking.rs
@@ -86,7 +86,7 @@ where
         if let Some(saved_session) = saved_session {
             merr!(unsafe {
                 mbedtls_ssl_set_session(
-                    &*self.state.ssl_context as *const _ as *mut _,
+                    &mut *self.state.ssl_context as *mut _,
                     &*saved_session.mbedtls_session,
                 )
             })?;
@@ -270,7 +270,7 @@ where
         // it needs to invoke them when we don't anticipate so (for bugs detection)
         unsafe {
             mbedtls_ssl_set_bio(
-                &*self.state.ssl_context as *const _ as *mut _,
+                &mut *self.state.ssl_context as *mut _,
                 core::ptr::null_mut(),
                 None,
                 None,

--- a/mbedtls-rs/tests/cert_key_ctor_aliasing.rs
+++ b/mbedtls-rs/tests/cert_key_ctor_aliasing.rs
@@ -1,0 +1,88 @@
+//! Standalone aliasing model for the F-32 cert/key constructor provenance fix.
+//!
+//! The real `MRc`/`Certificate`/`PrivateKey` constructors call MbedTLS C and
+//! cannot run under Miri, so (mirroring `async_split_aliasing.rs`) this test
+//! re-creates the exact pointer pattern the fix relies on: an `MRc`-shaped
+//! `NonNull<(T, usize)>` allocation whose inner `T` is mutated through a `*mut`
+//! projected from the allocation pointer via `addr_of_mut!`, by a fake "FFI"
+//! function that actually WRITES (a no-op stub would not exercise the access).
+//!
+//! What it validates under Tree Borrows:
+//! - Writing through a `*mut T` whose provenance is the unique allocation
+//!   pointer (not a shared `&`) is sound - this is what `MRc::as_mut_ptr` now
+//!   does. The old `&*mrc as *const _ as *mut _` shared-deref write that the fix
+//!   removes would fail here ("Frozen forbids child write").
+//! - The field projection targets `.0` (the inner value) and leaves `.1` (the
+//!   refcount) untouched, which is the `MRc`-tuple-specific property that makes
+//!   `addr_of_mut!((*ptr).0)` correct where `ptr.cast::<T>()` would be a
+//!   layout-assumption bug.
+
+use core::ptr::NonNull;
+
+// A stand-in for the hooked MbedTLS context (e.g. `mbedtls_x509_crt`): a struct
+// that C parses INTO, i.e. writes through the pointer we hand it.
+struct FakeCtx {
+    parsed: u32,
+    tag: u8,
+}
+
+// Fake "FFI": mutates THROUGH the raw pointer, exactly like
+// `mbedtls_x509_crt_parse`/`mbedtls_pk_parse_key` write into the context.
+unsafe fn fake_parse(ctx: *mut FakeCtx) -> i32 {
+    (*ctx).parsed = 0xC0FFEE;
+    (*ctx).tag = 7;
+    0
+}
+
+// An `MRc`-shaped owner: a `NonNull<(T, refcount)>` where the inner value is
+// field `.0` and the refcount is `.1`, mirroring `MRc<T>(NonNull<(T, usize)>)`.
+struct FakeMRc {
+    ptr: NonNull<(FakeCtx, usize)>,
+}
+
+impl FakeMRc {
+    fn new() -> Self {
+        // Heap-allocate the tuple, init the inner value, set refcount = 1 -
+        // mirroring `MRc::new`'s `mbedtls_calloc` + `init` + `.1 = 1`.
+        let boxed = Box::new((FakeCtx { parsed: 0, tag: 0 }, 1usize));
+        let ptr = NonNull::new(Box::into_raw(boxed)).unwrap();
+        Self { ptr }
+    }
+
+    // Mirror of `MRc::as_mut_ptr`: project `.0` from the allocation pointer with
+    // `addr_of_mut!`, never forming an intermediate reference, never casting.
+    fn as_mut_ptr(&mut self) -> *mut FakeCtx {
+        unsafe { core::ptr::addr_of_mut!((*self.ptr.as_ptr()).0) }
+    }
+
+    fn refcount(&self) -> usize {
+        unsafe { (*self.ptr.as_ptr()).1 }
+    }
+
+    fn parsed(&self) -> u32 {
+        unsafe { (*self.ptr.as_ptr()).0.parsed }
+    }
+}
+
+impl Drop for FakeMRc {
+    fn drop(&mut self) {
+        drop(unsafe { Box::from_raw(self.ptr.as_ptr()) });
+    }
+}
+
+#[test]
+fn write_through_unique_provenance_pointer_is_sound() {
+    let mut mrc = FakeMRc::new();
+    assert_eq!(mrc.refcount(), 1);
+
+    // Hand the projected `*mut` to the fake FFI, which writes through it -
+    // exactly the construction-time pattern in `Certificate::new` etc.
+    let rc = unsafe { fake_parse(mrc.as_mut_ptr()) };
+    assert_eq!(rc, 0);
+
+    // The write landed in the inner value (`.0`)...
+    assert_eq!(mrc.parsed(), 0xC0FFEE);
+    // ...and the refcount (`.1`) is untouched by the `.0` projection - proving
+    // the field projection does not disturb the tuple's second field.
+    assert_eq!(mrc.refcount(), 1);
+}


### PR DESCRIPTION
Hi Ivan, this is the constructor-side sibling of #147 (the async `ssl_context` provenance fix), found in the same audit. Same bug class, independent change.

## What

`Certificate::new`, `Certificate::new_no_copy` and `PrivateKey::new` obtained a `*mut` from a **shared** deref of the freshly-allocated `MRc` (`&*crt as *const _ as *mut _`, where `MRc` only implements `Deref`, not `DerefMut`) and let MbedTLS parse-write through it. Writing through a pointer whose provenance is a shared reference is UB under Stacked/Tree Borrows, and `mbedtls_x509_crt` / `mbedtls_pk_context` are not behind an `UnsafeCell`.

The two blocking-session sites did the same: `mbedtls_ssl_set_session` on resumption, and the second (callback-clearing) `mbedtls_ssl_set_bio`.

These run on every cert/key parse and on blocking session resumption.

## How

Carry write provenance from the owning allocation instead of a shared reference.

- New crate-private `MRc::as_mut_ptr` projects the inner value out of the `(T, usize)` allocation with `addr_of_mut!((*self.0.as_ptr()).0)` — field projection from the original `NonNull`, never forming an intermediate reference, and **not** `self.0.as_ptr().cast::<T>()` (the tuple field order is not guaranteed under `repr(Rust)`). The four cert/key parse sites use it. They are sound because the `MRc` is freshly allocated, has refcount 1, and is not cloned before the write.
- The two blocking sites use `&mut *self.state.ssl_context` (a unique borrow of the owning `MBox`). They intentionally do **not** use `MBox::as_mut_ptr` from #147, so this PR is independent of #147 and merges in any order.
- `MRc::as_mut_ptr` is more dangerous than `MBox::as_mut_ptr` because `MRc` is `Clone`, so its safety doc records that soundness rests on unique ownership at construction, not on `&mut self` alone.

The public API is unchanged, no new dependency, no `mbedtls-rs-sys` change.

## Scope note

Deliberately left as-is (reviewed, not the same bug):

- The `&mut`-derived `ssl_ctx as *const _ as *mut _` casts in the blocking `read`/`write`/`close` path — their `call_mbedtls` closure is handed `&mut self.state.ssl_context`, so they are unique-borrow-derived and sound (just ugly).
- The `mbedtls_ssl_conf_own_cert` / `conf_ca_chain` config casts — those APIs receive/store/read the cert/key pointer, they do not parse-write into the object, so not the same write-through bug.

## Testing

The real `MRc` and the constructors are private and constructing a real `Certificate`/`PrivateKey` needs the MbedTLS C library, so (mirroring `tests/async_split_aliasing.rs` from #147) `tests/cert_key_ctor_aliasing.rs` models the exact pointer pattern in isolation: an `MRc`-shaped `NonNull<(T, usize)>` whose inner `.0` is projected via `addr_of_mut!` and handed to a fake "FFI" function that actually writes through the `*mut`:

```
MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p mbedtls-rs --test cert_key_ctor_aliasing
```

passes under Tree Borrows. As a check, a temporary negative control (the old `&*mrc as *const _ as *mut _` shared-deref write) was confirmed to make Miri report `the accessed tag has state Frozen which forbids this child write access`, then removed — so the model detects the exact bug this PR removes. The harness mirrors `MRc::as_mut_ptr` rather than calling it (the helper is crate-private), so it locks the provenance property rather than the literal function; the assertion that the refcount `.1` is untouched also confirms the field projection targets `.0`.

Also verified: `cargo build`/`clippy`/`fmt --check` on `mbedtls-rs`, and the esp32c3 and esp32c2 example builds.