### PR TITLE
Make the wall-clock hook fallible and stop holding a critical section across it

### DIFF
--- a/mbedtls-rs-sys/src/hook/backend/esp/wall_clock.rs
+++ b/mbedtls-rs-sys/src/hook/backend/esp/wall_clock.rs
@@ -50,23 +50,21 @@ impl<'d, T> MbedtlsWallClock for EspRtcWallClock<'d, T>
 where
     T: core::borrow::Borrow<esp_hal::rtc_cntl::Rtc<'d>>,
 {
-    /// Returns the current time from the RTC.
+    /// Returns the current time from the RTC, or `None` if the RTC is
+    /// uninitialized or its value is outside the representable range (in which
+    /// case MbedTLS certificate validation fails closed rather than panicking).
     ///
-    /// # Panics
-    ///
-    /// Panics if the RTC time is out of the valid range for `OffsetDateTime`.
-    /// This can occur if the RTC was not properly initialized with a valid timestamp
-    /// (e.g., via NTP or manual setting).
-    fn instant(&self) -> tm {
-        let rtc_time_secs = (self.rtc.borrow().current_time_us() / 1_000_000) as i64;
+    /// An uninitialized RTC (for example before the time has been set via NTP)
+    /// is the common reason this returns `None`.
+    fn instant(&self) -> Option<tm> {
+        let rtc_time_secs = i64::try_from(self.rtc.borrow().current_time_us() / 1_000_000).ok()?;
 
-        let datetime = time::OffsetDateTime::from_unix_timestamp(rtc_time_secs)
-            .expect("RTC time out of range, ensure RTC is initialized with valid time");
+        let datetime = time::OffsetDateTime::from_unix_timestamp(rtc_time_secs).ok()?;
 
         let date = datetime.date();
         let time = datetime.time();
 
-        tm {
+        Some(tm {
             tm_sec: time.second() as i32,
             tm_min: time.minute() as i32,
             tm_hour: time.hour() as i32,
@@ -76,6 +74,6 @@ where
             tm_wday: date.weekday().number_days_from_sunday() as i32,
             tm_yday: date.ordinal() as i32 - 1, // MbedTLS uses 0-365
             tm_isdst: 0,
-        }
+        })
     }
 }

--- a/mbedtls-rs-sys/src/hook/backend/std/wall_clock.rs
+++ b/mbedtls-rs-sys/src/hook/backend/std/wall_clock.rs
@@ -12,30 +12,21 @@ use crate::hook::wall_clock::MbedtlsWallClock;
 pub struct StdWallClock;
 
 impl MbedtlsWallClock for StdWallClock {
-    /// Returns the current time from the system clock.
-    ///
-    /// # Panics
-    ///
-    /// Panics if:
-    /// - The system time is before the Unix epoch (January 1, 1970)
-    /// - The system time is out of the valid range for `OffsetDateTime`
-    ///
-    /// These conditions indicate a serious system clock misconfiguration that would
-    /// compromise TLS certificate validation.
-    fn instant(&self) -> tm {
-        let now = SystemTime::now();
-        let duration = now
+    /// Returns the current time from the system clock, or `None` if it is
+    /// before the Unix epoch or outside the representable range (in which case
+    /// MbedTLS certificate validation fails closed rather than panicking).
+    fn instant(&self) -> Option<tm> {
+        let duration = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("System time is before Unix epoch");
-        let timestamp = i64::try_from(duration.as_secs()).unwrap_or(i64::MAX);
+            .ok()?;
+        let timestamp = i64::try_from(duration.as_secs()).ok()?;
 
-        let datetime = time::OffsetDateTime::from_unix_timestamp(timestamp)
-            .expect("System time out of range for OffsetDateTime");
+        let datetime = time::OffsetDateTime::from_unix_timestamp(timestamp).ok()?;
 
         let date = datetime.date();
         let time = datetime.time();
 
-        tm {
+        Some(tm {
             tm_sec: time.second() as i32,
             tm_min: time.minute() as i32,
             tm_hour: time.hour() as i32,
@@ -45,6 +36,6 @@ impl MbedtlsWallClock for StdWallClock {
             tm_wday: date.weekday().number_days_from_sunday() as i32,
             tm_yday: date.ordinal() as i32 - 1, // 0-365
             tm_isdst: 0,
-        }
+        })
     }
 }

--- a/mbedtls-rs-sys/src/hook/wall_clock.rs
+++ b/mbedtls-rs-sys/src/hook/wall_clock.rs
@@ -3,7 +3,12 @@ use crate::tm;
 pub trait MbedtlsWallClock {
     /// Get current wall clock time as broken-down time structure.
     ///
-    /// Returns the current calendar time in UTC as a `tm` structure.
+    /// Returns the current calendar time in UTC as a `tm` structure, or `None`
+    /// if the wall clock is unavailable or its value cannot be represented (for
+    /// example an uninitialized RTC, or a timestamp outside the representable
+    /// range). When `None` is returned, MbedTLS X.509 certificate validation
+    /// fails closed: the certificate is treated as both expired and not yet
+    /// valid, so an unusable clock can never cause a certificate to be accepted.
     ///
     /// The `tm` struct contains the following fields:
     /// - `tm_sec`: seconds after the minute - [0, 60]
@@ -20,10 +25,7 @@ pub trait MbedtlsWallClock {
     /// This function should return the current wall clock time. The wall clock implementation is
     /// decoupled from the timer implementation (which provides monotonic timing for timeouts).
     /// MbedTLS uses this for X.509 certificate time validation.
-    ///
-    /// # Returns
-    /// - `tm` - Current time as a broken-down time structure
-    fn instant(&self) -> tm;
+    fn instant(&self) -> Option<tm>;
 }
 
 /// Hook the wall clock function
@@ -80,6 +82,9 @@ mod alt {
     /// Pointer to `tm_buf` on success, or null if:
     /// - `tm_buf` is null
     /// - No wall clock implementation is hooked
+    /// - The hooked implementation returned `None` (clock unavailable or
+    ///   unrepresentable), in which case MbedTLS certificate validation fails
+    ///   closed
     #[no_mangle]
     unsafe extern "C" fn mbedtls_platform_gmtime_r(
         _tt: *const mbedtls_time_t,
@@ -89,15 +94,18 @@ mod alt {
             return ptr::null_mut();
         }
 
-        critical_section::with(|cs| {
-            WALL_CLOCK
-                .borrow(cs)
-                .get()
-                .map(|wc| {
-                    *tm_buf = wc.instant();
-                    tm_buf
-                })
-                .unwrap_or_default()
-        })
+        // Copy the hook pointer out under the lock, then release the critical
+        // section BEFORE calling the user's `instant()`: that call may read an
+        // RTC over a bus and must not run with interrupts disabled (mirrors
+        // `mbedtls_ms_time` in `timer.rs`).
+        let wc = critical_section::with(|cs| WALL_CLOCK.borrow(cs).get());
+
+        match wc.and_then(|wc| wc.instant()) {
+            Some(now) => {
+                *tm_buf = now;
+                tm_buf
+            }
+            None => ptr::null_mut(),
+        }
     }
 }


### PR DESCRIPTION
Hi Ivan, as agreed in #149. Two small, related fixes in the wall-clock hook, both reachable from X.509 certificate validation.

## What

1. The crate's own wall-clock backends panic when the local clock is unusable: `StdWallClock` on a system time before the Unix epoch or out of range, and `EspRtcWallClock` on an uninitialized RTC (the normal state on boot before NTP). These are plain `extern "C"` callbacks under `panic = "abort"`, so a not-yet-set RTC aborts the device during the handshake instead of failing it.

2. `mbedtls_platform_gmtime_r` called the user hook `instant()` **inside** `critical_section::with` (interrupts disabled). The hook may read an RTC over a bus, which must not run with interrupts off.

## How

- `MbedtlsWallClock::instant` returns `Option<tm>` instead of `tm`. It had no way to signal "no valid time", which is why the backends were forced to `.expect()`. The backends now use `.ok()?` on every fallible step. I deliberately avoided clamping (e.g. to `i64::MAX` or epoch): a clamp to a fake time could let a certificate whose validity window happens to contain that fake time be accepted, so returning `None` is the safe choice.
- `mbedtls_platform_gmtime_r` returns `NULL` when the backend yields `None`. MbedTLS treats a NULL current-time as both expired and not-yet-valid (`mbedtls_x509_time_is_past` / `is_future` both return 1), so an unusable clock fails the certificate **closed** rather than aborting or silently accepting it.
- For the critical section: copy the hook pointer out under the lock and release before calling `instant()`, matching what `mbedtls_ms_time` in `timer.rs` already does.

This is a breaking change to `MbedtlsWallClock` (implementors now return `Option<tm>`, returning `None` for an unavailable/unrepresentable clock). No new dependency, no other API change.

## Note on scope

To be clear, and as you said in #149: this is not meant to over-sell flexibility. If the system has a wall clock at all, the TLS stack should not be started until that clock is in a trusted/valid state, otherwise certificate-time validation is meaningless. This change is just defense-in-depth: an unset clock now fails the handshake cleanly (and fails closed) instead of aborting the firmware, and it also handles timestamps that genuinely cannot be represented.

## Testing

`cargo build` / `clippy` / `fmt --check` on `mbedtls-rs-sys` with `std,hook-wall-clock,tls`, and the esp32c3 build with `esp32c3,hook-wall-clock,tls`. The fail-closed behaviour was checked against `mbedtls/library/x509.c` (`mbedtls_x509_time_is_past` / `is_future` return 1 when `gmtime_r` returns NULL). Only the two crate-owned backends and the `gmtime_r` shim change; the `timer.rs` callbacks already fall back to `0` and are untouched.