### PR TITLE
Harden the global RNG bridge: sound constructors and non-panicking FFI callbacks

### DIFF
--- a/examples/std/src/bin/blocking_client.rs
+++ b/examples/std/src/bin/blocking_client.rs
@@ -24,7 +24,10 @@ fn main() {
     info!("Initializing TLS");
 
     let mut rng = rng::StdRng;
-    let mut tls = Tls::new(&mut rng).unwrap();
+    // SAFETY: `rng` is declared before `tls` and outlives it; `tls` is dropped
+    // at the end of this scope and never leaked, so the borrow stays valid for
+    // the whole lifetime of the global RNG slot.
+    let mut tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
 
     tls.set_debug(1);
 

--- a/examples/std/src/bin/blocking_server.rs
+++ b/examples/std/src/bin/blocking_server.rs
@@ -32,7 +32,10 @@ fn main() {
     info!("Initializing TLS");
 
     let mut rng = rng::StdRng;
-    let mut tls = Tls::new(&mut rng).unwrap();
+    // SAFETY: `rng` is declared before `tls` and outlives it; `tls` is dropped
+    // at the end of this scope and never leaked, so the borrow stays valid for
+    // the whole lifetime of the global RNG slot.
+    let mut tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
 
     tls.set_debug(1);
 

--- a/examples/std/src/bin/client.rs
+++ b/examples/std/src/bin/client.rs
@@ -32,7 +32,10 @@ async fn run(buf: &mut [u8]) {
     info!("Initializing TLS");
 
     let mut rng = rng::StdRng;
-    let mut tls = Tls::new(&mut rng).unwrap();
+    // SAFETY: `rng` is declared before `tls` and outlives it; `tls` is dropped
+    // at the end of this scope and never leaked, so the borrow stays valid for
+    // the whole lifetime of the global RNG slot.
+    let mut tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
 
     tls.set_debug(1);
 

--- a/examples/std/src/bin/edge_client.rs
+++ b/examples/std/src/bin/edge_client.rs
@@ -26,7 +26,10 @@ async fn run(buf: &mut [u8]) {
     info!("Initializing TLS");
 
     let mut rng = rng::StdRng;
-    let mut tls = Tls::new(&mut rng).unwrap();
+    // SAFETY: `rng` is declared before `tls` and outlives it; `tls` is dropped
+    // at the end of this scope and never leaked, so the borrow stays valid for
+    // the whole lifetime of the global RNG slot.
+    let mut tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
 
     tls.set_debug(1);
 

--- a/examples/std/src/bin/edge_server.rs
+++ b/examples/std/src/bin/edge_server.rs
@@ -36,7 +36,10 @@ async fn run(server: &mut DemoServer) {
     info!("Initializing TLS");
 
     let mut rng = rng::StdRng;
-    let mut tls = Tls::new(&mut rng).unwrap();
+    // SAFETY: `rng` is declared before `tls` and outlives it; `tls` is dropped
+    // at the end of this scope and never leaked, so the borrow stays valid for
+    // the whole lifetime of the global RNG slot.
+    let mut tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
 
     tls.set_debug(1);
 

--- a/examples/std/src/bin/server.rs
+++ b/examples/std/src/bin/server.rs
@@ -39,7 +39,10 @@ async fn run() {
     info!("Initializing TLS");
 
     let mut rng = rng::StdRng;
-    let mut tls = Tls::new(&mut rng).unwrap();
+    // SAFETY: `rng` is declared before `tls` and outlives it; `tls` is dropped
+    // at the end of this scope and never leaked, so the borrow stays valid for
+    // the whole lifetime of the global RNG slot.
+    let mut tls = unsafe { Tls::new_local_borrows(&mut rng) }.unwrap();
 
     tls.set_debug(0);
 

--- a/mbedtls-rs/src/lib.rs
+++ b/mbedtls-rs/src/lib.rs
@@ -43,7 +43,24 @@ pub mod sys {
     pub use mbedtls_rs_sys::*;
 }
 
-static RNG: Mutex<RefCell<Option<&mut (dyn CryptoRng + Send)>>> = Mutex::new(RefCell::new(None));
+/// An erased pointer to the user-provided RNG, stored in the global [`RNG`].
+///
+/// The RNG is stored as a raw `NonNull` rather than a reference: a pointer
+/// makes no aliasing/validity claim, and the `&mut` is materialized only inside
+/// the `mbedtls_rng` callback. [`Tls::new`] takes a `&'static mut`, so its
+/// stored pointer is always valid. [`Tls::new_local_borrows`] takes a shorter
+/// `&'d mut` and is `unsafe` precisely because of this slot: if that borrow ends
+/// while the pointer is still installed (only reachable by leaking the `Tls`),
+/// a later callback dereference would be UB. See `new_local_borrows`' safety
+/// contract.
+struct RngPtr(NonNull<dyn CryptoRng + Send>);
+
+// SAFETY: the pointee is `Send` (the trait object bound), and all access is
+// serialized through the `critical_section` `Mutex` below. The pointer is set
+// from a live `&mut` in a `Tls` constructor and cleared in `Tls::drop`.
+unsafe impl Send for RngPtr {}
+
+static RNG: Mutex<RefCell<Option<RngPtr>>> = Mutex::new(RefCell::new(None));
 
 /// An error returned when creating a `Tls` instance
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -58,25 +75,69 @@ pub enum TlsError {
 /// Only one such instance can be active at any point in time.
 pub struct Tls<'d>(PhantomData<&'d mut ()>);
 
-impl<'d> Tls<'d> {
-    /// Create a new instance of the `Tls` type.
+impl Tls<'static> {
+    /// Create a new instance of the `Tls` type from a `'static` RNG.
     ///
-    /// Note that there could be only one active `Tls` instance at any point in time,
-    /// and the function will return an error if there is already an active instance.
-    pub fn new(rng: &'d mut (dyn CryptoRng + Send)) -> Result<Self, TlsError> {
-        critical_section::with(|cs| {
-            let created = RNG.borrow(cs).borrow().is_some();
+    /// Note that there could be only one active `Tls` instance at any point in
+    /// time, and the function will return an error if there is already an active
+    /// instance.
+    ///
+    /// This is safe because the RNG borrow is `'static`: it stays valid for the
+    /// rest of the program, so even leaking the returned `Tls` (e.g. via
+    /// `core::mem::forget`) cannot leave the global RNG slot dangling. For a
+    /// shorter-lived borrow, see [`Tls::new_local_borrows`].
+    pub fn new(rng: &'static mut (dyn CryptoRng + Send)) -> Result<Self, TlsError> {
+        // No `unsafe`: a `&'static mut` is already valid for the program's
+        // lifetime, so `NonNull::from` erases nothing the caller could invalidate.
+        Self::store_rng(NonNull::from(rng))
+    }
+}
 
-            if created {
+impl<'d> Tls<'d> {
+    /// Create a new instance of the `Tls` type from a non-`'static` RNG.
+    ///
+    /// Note that there could be only one active `Tls` instance at any point in
+    /// time, and the function will return an error if there is already an active
+    /// instance.
+    ///
+    /// Prefer [`Tls::new`] with a `'static` RNG where possible; this variant
+    /// exists for borrowed RNGs (e.g. a hardware TRNG peripheral) that cannot be
+    /// `'static`.
+    ///
+    /// # Safety
+    /// The RNG is stored behind a lifetime-erased pointer for as long as the
+    /// global RNG slot is installed (until this `Tls` is dropped). The caller
+    /// must ensure the returned `Tls` is dropped - NOT leaked via
+    /// `core::mem::forget` / `ManuallyDrop` - before `rng`'s borrow ends, and
+    /// must not combine a leaked `Tls` with direct calls into the raw
+    /// `mbedtls-rs-sys` RNG/PSA bindings; otherwise a later callback may
+    /// dereference a dangling pointer. Using only the safe `Session` API upholds
+    /// this automatically (a `Session` keeps the `Tls` alive via `TlsReference`).
+    pub unsafe fn new_local_borrows(rng: &'d mut (dyn CryptoRng + Send)) -> Result<Self, TlsError> {
+        // SAFETY: erase only the pointee lifetime on a *pointer* (ptr -> ptr, no
+        // validity claim); the caller upholds the no-leak contract documented
+        // above. The transmute preserves the data pointer and vtable.
+        let rng = unsafe {
+            core::mem::transmute::<NonNull<dyn CryptoRng + Send + '_>, NonNull<dyn CryptoRng + Send>>(
+                NonNull::from(rng),
+            )
+        };
+        Self::store_rng(rng)
+    }
+}
+
+impl<'d> Tls<'d> {
+    /// Install the erased RNG pointer into the global slot, enforcing the
+    /// single-active-instance invariant. Safe: storing a `NonNull` asserts
+    /// nothing about the pointee; validity is the contract of whichever
+    /// constructor produced the pointer.
+    fn store_rng(rng: NonNull<dyn CryptoRng + Send>) -> Result<Self, TlsError> {
+        critical_section::with(|cs| {
+            if RNG.borrow(cs).borrow().is_some() {
                 return Err(TlsError::AlreadyCreated);
             }
 
-            *RNG.borrow(cs).borrow_mut() = Some(unsafe {
-                core::mem::transmute::<
-                    &'d mut (dyn CryptoRng + Send),
-                    &'static mut (dyn CryptoRng + Send),
-                >(rng)
-            });
+            *RNG.borrow(cs).borrow_mut() = Some(RngPtr(rng));
 
             Ok(Self(PhantomData))
         })
@@ -460,15 +521,37 @@ pub(crate) unsafe extern "C" fn mbedtls_rng(
     buf: *mut c_uchar,
     len: usize,
 ) -> c_int {
-    let buf = core::slice::from_raw_parts_mut(buf, len as _);
+    use crate::sys::MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED;
+
+    if len == 0 {
+        return 0;
+    }
+    if buf.is_null() {
+        return MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED;
+    }
+
+    let buf = core::slice::from_raw_parts_mut(buf, len);
 
     critical_section::with(|cs| {
-        let mut rng = RNG.borrow(cs).borrow_mut();
-
-        rng.as_mut().unwrap().fill_bytes(buf);
-    });
-
-    0
+        match RNG.borrow(cs).borrow_mut().as_mut() {
+            // SAFETY: the pointer was set from a live `&mut` in a `Tls`
+            // constructor (`store_rng`) and is cleared in `Tls::drop`, so on the
+            // normal path (a live `Tls`) it is valid; access is serialized by the
+            // surrounding `Mutex`. The one unsound path is a leaked `Tls` created
+            // via `new_local_borrows` (see `RngPtr`): if the owner did
+            // `mem::forget` and dropped the RNG, this slot is stale. That is a
+            // caller contract, not something this callback can detect.
+            Some(rng) => {
+                rng.0.as_mut().fill_bytes(buf);
+                0
+            }
+            // No `Tls` is active: report an entropy failure rather than panicking
+            // (the old `unwrap()` aborted out of this `extern "C"` callback). This
+            // path is reachable via `mbedtls_psa_external_get_random`, which the
+            // PSA layer can call with no live `Session`.
+            None => MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED,
+        }
+    })
 }
 
 #[no_mangle]
@@ -478,8 +561,31 @@ unsafe extern "C" fn mbedtls_psa_external_get_random(
     out_size: usize,
     output_len: *mut usize,
 ) -> c_int {
-    *output_len = out_size;
-    mbedtls_rng(core::ptr::null_mut(), output, out_size)
+    // PSA status codes (`psa_status_t`). MbedTLS treats this hook's return as a
+    // PSA status, not an `MBEDTLS_ERR_*` code, and the generated bindings do not
+    // expose the `PSA_*` macros, so they are defined locally here.
+    const PSA_SUCCESS: c_int = 0;
+    const PSA_ERROR_INSUFFICIENT_ENTROPY: c_int = -148;
+    const PSA_ERROR_INVALID_ARGUMENT: c_int = -135;
+
+    if output_len.is_null() {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+    // A zero-size request may legitimately pass a null `output`.
+    if output.is_null() && out_size != 0 {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+    if out_size == 0 {
+        *output_len = 0;
+        return PSA_SUCCESS;
+    }
+
+    if mbedtls_rng(core::ptr::null_mut(), output, out_size) == 0 {
+        *output_len = out_size;
+        PSA_SUCCESS
+    } else {
+        PSA_ERROR_INSUFFICIENT_ENTROPY
+    }
 }
 
 #[cfg(target_os = "espidf")]

--- a/mbedtls-rs/tests/rng_ffi.rs
+++ b/mbedtls-rs/tests/rng_ffi.rs
@@ -1,0 +1,126 @@
+//! Behavioural lock for the RNG FFI shims' return contract (F-16 + F-17).
+//!
+//! `mbedtls_rng` and `mbedtls_psa_external_get_random` are `pub(crate)` /
+//! private FFI callbacks, and `mbedtls-rs` is `#![no_std]` with
+//! `[lib] harness = false`, so the real shims cannot be driven from a `tests/`
+//! integration crate (which compiles as a separate std crate and only sees the
+//! public API). Mirroring how `cert_key_ctor_aliasing.rs` / `blocking_eof.rs`
+//! lock their private logic, this re-creates the shims' decision contract in
+//! isolation and asserts the exact return codes. NOTE: it does NOT call the real
+//! shims, so it cannot detect production drift on its own; it pins the intended
+//! contract (the constants and branch outcomes) so that a change to them is a
+//! visible, reviewed edit to BOTH this file and `lib.rs`.
+//!
+//! The constants below MUST match the production code in `lib.rs`:
+//! - `mbedtls_rng` returns `MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED` (-52)
+//!   on no-RNG / null buffer, and `0` for a zero-length request.
+//! - `mbedtls_psa_external_get_random` returns `psa_status_t` values:
+//!   `PSA_SUCCESS` (0), `PSA_ERROR_INVALID_ARGUMENT` (-135),
+//!   `PSA_ERROR_INSUFFICIENT_ENTROPY` (-148).
+
+const MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED: i32 = -52;
+const PSA_SUCCESS: i32 = 0;
+const PSA_ERROR_INVALID_ARGUMENT: i32 = -135;
+const PSA_ERROR_INSUFFICIENT_ENTROPY: i32 = -148;
+
+/// Mirror of `mbedtls_rng`'s decision logic (no FFI, no global RNG): `rng_present`
+/// stands in for "a `Tls` is active", `buf_null`/`len` for the raw arguments.
+fn rng_contract(rng_present: bool, buf_null: bool, len: usize) -> i32 {
+    if len == 0 {
+        return 0;
+    }
+    if buf_null {
+        return MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED;
+    }
+    if rng_present {
+        0
+    } else {
+        MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED
+    }
+}
+
+/// Mirror of `mbedtls_psa_external_get_random`'s decision logic.
+fn psa_contract(
+    output_null: bool,
+    output_len_null: bool,
+    out_size: usize,
+    rng_present: bool,
+) -> i32 {
+    if output_len_null {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+    if output_null && out_size != 0 {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+    if out_size == 0 {
+        return PSA_SUCCESS;
+    }
+    if rng_contract(rng_present, output_null, out_size) == 0 {
+        PSA_SUCCESS
+    } else {
+        PSA_ERROR_INSUFFICIENT_ENTROPY
+    }
+}
+
+#[test]
+fn rng_no_tls_returns_entropy_failure_not_panic() {
+    // The old code did `rng.as_mut().unwrap()` -> panic/abort here.
+    assert_eq!(
+        rng_contract(false, false, 32),
+        MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED
+    );
+}
+
+#[test]
+fn rng_null_buffer_returns_entropy_failure() {
+    assert_eq!(
+        rng_contract(true, true, 32),
+        MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED
+    );
+}
+
+#[test]
+fn rng_zero_length_returns_ok_without_touching_buffer() {
+    // len == 0 short-circuits before building a slice from a possibly-null ptr.
+    assert_eq!(rng_contract(true, true, 0), 0);
+}
+
+#[test]
+fn rng_happy_path_returns_ok() {
+    assert_eq!(rng_contract(true, false, 32), 0);
+}
+
+#[test]
+fn psa_null_output_len_is_invalid_argument() {
+    assert_eq!(
+        psa_contract(false, true, 32, true),
+        PSA_ERROR_INVALID_ARGUMENT
+    );
+}
+
+#[test]
+fn psa_null_output_with_nonzero_size_is_invalid_argument() {
+    assert_eq!(
+        psa_contract(true, false, 32, true),
+        PSA_ERROR_INVALID_ARGUMENT
+    );
+}
+
+#[test]
+fn psa_zero_size_with_null_output_is_success() {
+    // A zero-size request may legitimately pass a null `output`.
+    assert_eq!(psa_contract(true, false, 0, true), PSA_SUCCESS);
+}
+
+#[test]
+fn psa_no_tls_maps_to_insufficient_entropy_not_mbedtls_err() {
+    // Must be the PSA status -148, NOT the mbedtls -52.
+    let rc = psa_contract(false, false, 32, false);
+    assert_eq!(rc, PSA_ERROR_INSUFFICIENT_ENTROPY);
+    assert_ne!(rc, MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED);
+}
+
+#[test]
+fn psa_happy_path_is_success() {
+    assert_eq!(psa_contract(false, false, 32, true), PSA_SUCCESS);
+}


### PR DESCRIPTION
Hi Ivan, this implements the `Tls::new` split we agreed on in #153, plus a related robustness fix to the RNG FFI callbacks found in the same audit. One combined PR per your "don't split out".

## What

The user RNG is installed into a global slot read by MbedTLS's `f_rng` and the PSA external-RNG callbacks. Two things are addressed.

**Constructor soundness (#153).** The RNG was stored by transmuting the `&'d mut` borrow to `&'static mut`, which a safe `mem::forget(tls)` could strand as a dangling reference. This stores an erased `NonNull` instead (no aliasing/validity claim, materialized back to `&mut` only inside the callback) and splits the constructor per your suggestion:

- a safe `Tls::new(rng: &'static mut (dyn CryptoRng + Send))` on `impl Tls<'static>` - leaking the `Tls` can never dangle a `'static` borrow, so it needs no `unsafe`;
- an `unsafe fn new_local_borrows` for a shorter borrow (e.g. a hardware TRNG peripheral), whose `# Safety` contract forbids leaking the `Tls` before the borrow ends or combining such a leak with raw `mbedtls-rs-sys` RNG/PSA calls. The safe `Session` API upholds this automatically (it keeps the `Tls` alive via `TlsReference`).

This is a breaking change to `Tls::new` (you noted on #149 that's fine for now). The `std` examples move to `new_local_borrows` (their RNG is a stack local that lexically outlives the `Tls`); the ESP examples already pass a `mk_static!` `&'static mut` and use the safe `new` unchanged.

**Callback robustness.** `mbedtls_rng` no longer panics across the `extern "C"` boundary when no `Tls` is active - reachable via `mbedtls_psa_external_get_random`, which the PSA layer can call with no live `Session`. It now returns `MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED` and guards zero-length / null-buffer requests. `mbedtls_psa_external_get_random` returns proper `psa_status_t` values and only writes `*output_len` on success.

`rng_ffi.rs` locks the callbacks' return contract.
