### PR TITLE
Bind a saved session to its server name and reject cross-host resume

### DIFF
--- a/mbedtls-rs/src/session.rs
+++ b/mbedtls-rs/src/session.rs
@@ -15,9 +15,96 @@ pub use asynch::*;
 mod asynch;
 pub mod blocking;
 
+/// An owned, nul-terminated server name allocated through MbedTLS's allocator
+/// (`mbedtls_calloc`/`mbedtls_free`), so it honours a user-overridden MbedTLS
+/// heap instead of the Rust global allocator. Used to bind a saved session to a
+/// peer identity (see [`SavedSession`]).
+pub(crate) struct ServerName {
+    ptr: NonNull<u8>,
+}
+
+impl ServerName {
+    /// Copy a `&CStr`'s bytes (including the nul) into a fresh MbedTLS-allocated
+    /// buffer. Returns `None` if the allocation fails.
+    fn from_cstr(name: &CStr) -> Option<Self> {
+        Self::from_bytes_with_nul(name.to_bytes_with_nul())
+    }
+
+    fn from_bytes_with_nul(bytes: &[u8]) -> Option<Self> {
+        // SAFETY: `mbedtls_calloc` is the MbedTLS allocator entry point; requesting
+        // `bytes.len()` elements of one byte each yields a `bytes.len()`-byte (or
+        // null) allocation, which `NonNull::new` checks before we treat it as owned.
+        let ptr =
+            NonNull::new(unsafe { mbedtls_calloc(bytes.len(), size_of::<u8>()) }.cast::<u8>())?;
+
+        // SAFETY: `ptr` points to a fresh `bytes.len()`-byte allocation, and the
+        // source slice is independent of it.
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr.as_ptr(), bytes.len());
+        }
+
+        Some(Self { ptr })
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        // SAFETY: `ptr` was constructed from a nul-terminated source slice in
+        // `from_bytes_with_nul` and is never mutated after construction.
+        unsafe { CStr::from_ptr(self.ptr.as_ptr().cast::<c_char>()) }.to_bytes_with_nul()
+    }
+}
+
+impl Drop for ServerName {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` was allocated by `mbedtls_calloc` in `from_bytes_with_nul`,
+        // is owned solely by this `ServerName`, and is freed exactly once here.
+        unsafe {
+            mbedtls_free(self.ptr.as_ptr() as *mut c_void);
+        }
+    }
+}
+
 /// A reusable TLS session state captured from a connected session.
+///
+/// A saved session is bound to the server name that was configured when it was
+/// captured, and [`Session::connect_with_session`] refuses to resume it against
+/// a different server name (see that method). A session captured without a
+/// server name carries no peer binding and may only be resumed into an equally
+/// nameless session.
 pub struct SavedSession {
     pub(crate) mbedtls_session: MBox<mbedtls_ssl_session>,
+    /// The server name the originating session was configured with, used to
+    /// reject cross-host resume. `None` if the session had no server name.
+    pub(crate) server_name: Option<ServerName>,
+}
+
+/// Reject reusing a saved session against a different peer identity.
+///
+/// TLS 1.2 resume acceptance does not re-validate the server certificate, so a
+/// session saved for host A presented to a server B that accepts it would skip
+/// verifying B's certificate. We enforce the binding in the wrapper for both TLS
+/// 1.2 and 1.3 (1.3 also checks in C). `None`/`Some` are treated as distinct, so
+/// a nameless saved session only resumes into a nameless session.
+pub(crate) fn check_saved_session_server_name(
+    saved: &Option<ServerName>,
+    current: *const c_char,
+) -> Result<(), SessionError> {
+    let current_bytes: Option<&[u8]> = if current.is_null() {
+        None
+    } else {
+        // SAFETY: a non-null hostname pointer read from `mbedtls_ssl_context`
+        // is a heap-allocated, nul-terminated string owned by the SSL context.
+        // The borrow only lives for the synchronous byte comparison below.
+        Some(unsafe { CStr::from_ptr(current) }.to_bytes_with_nul())
+    };
+    let saved_bytes = saved.as_ref().map(|n| n.as_bytes());
+
+    if current_bytes == saved_bytes {
+        Ok(())
+    } else {
+        Err(SessionError::MbedTls(MbedtlsError::new(
+            MBEDTLS_ERR_SSL_BAD_INPUT_DATA,
+        )))
+    }
 }
 
 /// Certificate verification mode used for a session
@@ -325,10 +412,8 @@ impl<'a> SessionState<'a> {
         merr!(unsafe { mbedtls_ssl_setup(&mut *ssl_context, &*ssl_config) })?;
 
         if let SessionConfig::Client(conf) = conf {
-            if let Some(server_name) = conf.server_name {
-                merr!(unsafe {
-                    mbedtls_ssl_set_hostname(&mut *ssl_context, server_name.as_ptr())
-                })?;
+            if let Some(name) = conf.server_name {
+                merr!(unsafe { mbedtls_ssl_set_hostname(&mut *ssl_context, name.as_ptr()) })?;
             }
         }
 

--- a/mbedtls-rs/src/session/asynch.rs
+++ b/mbedtls-rs/src/session/asynch.rs
@@ -11,7 +11,9 @@ use io::{ErrorType, Read, Write};
 use crate::sys::*;
 use crate::{SessionError, TlsReference};
 
-use super::{SavedSession, SessionConfig, SessionState};
+use super::{
+    check_saved_session_server_name, SavedSession, ServerName, SessionConfig, SessionState,
+};
 
 /// Re-export of the `embedded-io-async` crate so that users don't have to explicitly depend on it
 /// to use e.g. `write_all` or `read_exact`.
@@ -108,11 +110,23 @@ where
         &mut self.stream
     }
 
-    /// Set the server name for the TLS connection
+    /// Set the server name for the TLS connection.
+    ///
+    /// Must be called before the handshake is triggered (by `connect`,
+    /// `connect_with_session`, `read`, `write`, or `split`); changing the server
+    /// name on an already-connected session is rejected, because the saved
+    /// session would otherwise be bound to a name that was not used to negotiate
+    /// it.
     ///
     /// # Arguments
     /// - `server_name`: The server name as a C string
     pub fn set_server_name(&mut self, server_name: &CStr) -> Result<(), SessionError> {
+        if self.connected {
+            return Err(SessionError::MbedTls(MbedtlsError::new(
+                MBEDTLS_ERR_SSL_BAD_INPUT_DATA,
+            )));
+        }
+
         merr!(unsafe {
             mbedtls_ssl_set_hostname(&mut *self.state.ssl_context, server_name.as_ptr())
         })?;
@@ -126,6 +140,16 @@ where
     ) -> Result<(), SessionError> {
         if self.connected {
             return Ok(());
+        }
+
+        // Reject resuming a session captured for a different server name before
+        // it can be installed (cross-host resume can skip cert validation on
+        // TLS 1.2). See `check_saved_session_server_name`.
+        if let Some(saved_session) = saved_session {
+            check_saved_session_server_name(
+                &saved_session.server_name,
+                self.state.ssl_context.private_hostname,
+            )?;
         }
 
         MBio::from_session(self).connect(saved_session).await?;
@@ -269,7 +293,24 @@ where
 
         merr!(unsafe { mbedtls_ssl_get_session(&*self.state.ssl_context, &mut *mbedtls_session) })?;
 
-        Ok(SavedSession { mbedtls_session })
+        let hostname_ptr = self.state.ssl_context.private_hostname;
+        let server_name = if hostname_ptr.is_null() {
+            None
+        } else {
+            // SAFETY: a non-null hostname pointer on `mbedtls_ssl_context` is a
+            // heap-allocated, nul-terminated string owned by the SSL context;
+            // we only borrow it long enough to copy its bytes.
+            let cstr = unsafe { CStr::from_ptr(hostname_ptr) };
+            Some(
+                ServerName::from_cstr(cstr)
+                    .ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?,
+            )
+        };
+
+        Ok(SavedSession {
+            mbedtls_session,
+            server_name,
+        })
     }
 }
 

--- a/mbedtls-rs/src/session/blocking.rs
+++ b/mbedtls-rs/src/session/blocking.rs
@@ -4,7 +4,10 @@ use io::{Error, ErrorKind, ErrorType, Read, Write};
 
 use crate::sys::*;
 
-use super::{SavedSession, SessionConfig, SessionError, SessionState, TlsReference};
+use super::{
+    check_saved_session_server_name, SavedSession, ServerName, SessionConfig, SessionError,
+    SessionState, TlsReference,
+};
 
 /// Re-export of the `embedded-io` crate so that users don't have to explicitly depend on it
 /// to use e.g. `write_all` or `read_exact`.
@@ -69,11 +72,22 @@ where
         &mut self.stream
     }
 
-    /// Set the server name for the TLS connection
+    /// Set the server name for the TLS connection.
+    ///
+    /// Must be called before the handshake is triggered (by `connect`,
+    /// `connect_with_session`, `read`, or `write`); changing the server name on
+    /// an already-connected session is rejected, because the saved session would
+    /// otherwise be bound to a name that was not used to negotiate it.
     ///
     /// # Arguments
     /// - `server_name`: The server name as a C string
     pub fn set_server_name(&mut self, server_name: &CStr) -> Result<(), SessionError> {
+        if self.connected {
+            return Err(SessionError::MbedTls(MbedtlsError::new(
+                MBEDTLS_ERR_SSL_BAD_INPUT_DATA,
+            )));
+        }
+
         merr!(unsafe {
             mbedtls_ssl_set_hostname(&mut *self.state.ssl_context, server_name.as_ptr())
         })?;
@@ -92,6 +106,14 @@ where
         merr!(unsafe { mbedtls_ssl_session_reset(&mut *self.state.ssl_context) })?;
 
         if let Some(saved_session) = saved_session {
+            // Reject resuming a session captured for a different server name
+            // before installing it (cross-host resume can skip cert validation
+            // on TLS 1.2). See `check_saved_session_server_name`.
+            check_saved_session_server_name(
+                &saved_session.server_name,
+                self.state.ssl_context.private_hostname,
+            )?;
+
             merr!(unsafe {
                 mbedtls_ssl_set_session(
                     &mut *self.state.ssl_context as *mut _,
@@ -375,7 +397,24 @@ where
 
         merr!(unsafe { mbedtls_ssl_get_session(&*self.state.ssl_context, &mut *mbedtls_session) })?;
 
-        Ok(SavedSession { mbedtls_session })
+        let hostname_ptr = self.state.ssl_context.private_hostname;
+        let server_name = if hostname_ptr.is_null() {
+            None
+        } else {
+            // SAFETY: a non-null hostname pointer on `mbedtls_ssl_context` is a
+            // heap-allocated, nul-terminated string owned by the SSL context;
+            // we only borrow it long enough to copy its bytes.
+            let cstr = unsafe { CStr::from_ptr(hostname_ptr) };
+            Some(
+                ServerName::from_cstr(cstr)
+                    .ok_or(MbedtlsError::new(MBEDTLS_ERR_SSL_ALLOC_FAILED))?,
+            )
+        };
+
+        Ok(SavedSession {
+            mbedtls_session,
+            server_name,
+        })
     }
 }
 

--- a/mbedtls-rs/tests/saved_session_binding.rs
+++ b/mbedtls-rs/tests/saved_session_binding.rs
@@ -1,0 +1,65 @@
+//! Behavioral lock for the saved-session peer-binding check (F-34).
+//!
+//! `check_saved_session_server_name` is `pub(crate)` and the comparison runs
+//! inside `connect_internal` behind a TLS handshake (needs the MbedTLS C library
+//! plus a live peer), so (like `rng_ffi.rs` / `blocking_eof.rs`) this test
+//! re-creates the exact decision logic the fix relies on rather than calling the
+//! real function. It does NOT exercise the real shim, so it cannot catch
+//! production drift on its own; it pins the intended contract so a change is a
+//! visible, reviewed edit to BOTH this file and `session.rs`.
+//!
+//! Contract: a saved session may only be resumed against the same configured
+//! server name. A mismatch (including `None` vs `Some`) is rejected with
+//! `MBEDTLS_ERR_SSL_BAD_INPUT_DATA`, reusing the existing error path rather than
+//! a new `SessionError` variant.
+
+// Mirrors the real MbedTLS constant the fix returns on mismatch.
+const MBEDTLS_ERR_SSL_BAD_INPUT_DATA: i32 = -0x7100;
+
+/// Re-creation of `check_saved_session_server_name`: `Ok(())` if the saved and
+/// current server names are equal, otherwise the `BAD_INPUT_DATA` error code.
+fn check(saved: &Option<Vec<u8>>, current: &Option<Vec<u8>>) -> Result<(), i32> {
+    if saved == current {
+        Ok(())
+    } else {
+        Err(MBEDTLS_ERR_SSL_BAD_INPUT_DATA)
+    }
+}
+
+#[test]
+fn different_server_names_are_rejected() {
+    let saved = Some(b"a.example\0".to_vec());
+    let current = Some(b"b.example\0".to_vec());
+    assert_eq!(check(&saved, &current), Err(MBEDTLS_ERR_SSL_BAD_INPUT_DATA));
+}
+
+#[test]
+fn matching_server_names_are_accepted() {
+    let saved = Some(b"a.example\0".to_vec());
+    let current = Some(b"a.example\0".to_vec());
+    assert_eq!(check(&saved, &current), Ok(()));
+}
+
+#[test]
+fn nameless_saved_into_named_is_rejected() {
+    // A session saved with no server name carries no peer binding and must not
+    // silently resume into a named session.
+    let saved = None;
+    let current = Some(b"a.example\0".to_vec());
+    assert_eq!(check(&saved, &current), Err(MBEDTLS_ERR_SSL_BAD_INPUT_DATA));
+}
+
+#[test]
+fn named_saved_into_nameless_is_rejected() {
+    let saved = Some(b"a.example\0".to_vec());
+    let current = None;
+    assert_eq!(check(&saved, &current), Err(MBEDTLS_ERR_SSL_BAD_INPUT_DATA));
+}
+
+#[test]
+fn both_nameless_is_accepted() {
+    // Equally-nameless is the only case where a no-binding session may resume.
+    let saved: Option<Vec<u8>> = None;
+    let current: Option<Vec<u8>> = None;
+    assert_eq!(check(&saved, &current), Ok(()));
+}


### PR DESCRIPTION
Hi Ivan, another finding from the same audit, independent of the others.

## What

`SavedSession` carries no peer binding: `connect_with_session` feeds it to any new session via `mbedtls_ssl_set_session` regardless of server name. On **TLS 1.2** a resumed handshake jumps straight to the change-cipher-spec state and **skips the certificate parse/verify states**, so a session saved for host A presented to a server B that accepts it (shared resumption secret / same infra) resumes and **skips validating B's certificate**. TLS 1.3 already rejects a ticket-hostname mismatch in C; TLS 1.2 does not.

## Fix

Track the configured server name in the session and store it in `SavedSession`, then reject a mismatch with `MBEDTLS_ERR_SSL_BAD_INPUT_DATA` **before** installing the saved session, in both the async and blocking `connect_internal`. The check covers both protocol versions (defence in depth; 1.3 already enforces in C). `set_server_name` is also rejected after the handshake, so a saved session can't be bound to a name that wasn't used to negotiate it.

Reuses the existing error path rather than adding a `SessionError` variant. `SavedSession` gains a private field, so it's not a Rust source break.

## Behaviour change

- A cross-host `connect_with_session` that previously resumed now returns an error (the point of the fix).
- `set_server_name` after the handshake now errors.
- A session saved without a server name carries no peer binding and may only be resumed into an equally nameless session.

Adds `saved_session_binding.rs` locking the comparison contract.
