### PR TITLE
Conform to MbedTLS *_free(NULL) C contract in hash hooks

### DIFF
--- a/mbedtls-rs-sys/src/hook/digest.rs
+++ b/mbedtls-rs-sys/src/hook/digest.rs
@@ -176,7 +176,20 @@ unsafe fn digest_init<T: WorkArea>(algo: &dyn MbedtlsDigest, memory: *mut T) {
 #[allow(unused)]
 #[inline(always)]
 unsafe fn digest_free<T: WorkArea>(algo: &dyn MbedtlsDigest, memory: *mut T) {
-    algo.free(memory.as_mut().unwrap().memory_mut());
+    // MbedTLS upstream contract: `mbedtls_*_free(NULL)` is explicitly documented
+    // as valid (sha1.h:76-82, sha256.h, sha512.h: "ctx ... may be NULL, in which
+    // case this function returns immediately"). No current caller in MbedTLS 3.x
+    // actually passes NULL: `mbedtls_md_free` (md.c:282) NULL-checks `ctx->md_ctx`
+    // before dispatch, PSA hash code passes `&operation->ctx` (struct field), and
+    // the SHA self-tests pass `&ctx` (stack variable). The contract is forward-
+    // compatible / defensive: when our `MBEDTLS_SHA*_ALT` hook replaces the
+    // upstream implementation, any future caller that elects to pass NULL through
+    // would land here, and panicking across the FFI boundary is strictly worse
+    // than the documented no-op.
+    let Some(memory) = memory.as_mut() else {
+        return;
+    };
+    algo.free(memory.memory_mut());
 }
 
 #[allow(unused)]

--- a/mbedtls-rs-sys/src/hook/digest/sha256.rs
+++ b/mbedtls-rs-sys/src/hook/digest/sha256.rs
@@ -10,7 +10,7 @@ pub trait MbedtlsSha224: MbedtlsDigest {}
 impl<T: Deref> MbedtlsSha256 for T where T::Target: MbedtlsSha256 {}
 impl<T: Deref> MbedtlsSha224 for T where T::Target: MbedtlsSha224 {}
 
-/// Hook the SHA1 implementation used by MbedTLS
+/// Hook the SHA-256 implementation used by MbedTLS
 ///
 /// # Safety
 /// - This function is unsafe because it modifies global state that affects
@@ -117,6 +117,13 @@ mod alt {
 
     #[no_mangle]
     unsafe extern "C" fn mbedtls_sha256_free(ctx: *mut mbedtls_sha256_context) {
+        // MbedTLS contract: `mbedtls_sha256_free(NULL)` is documented as valid
+        // (see `digest_free` in `mbedtls-rs-sys/src/hook/digest.rs` for the
+        // full call-path rationale). Null-check before `algo(ctx)` because that
+        // helper dereferences `ctx` to read `is224`.
+        if ctx.is_null() {
+            return;
+        }
         digest_free(algo(ctx), ctx);
     }
 

--- a/mbedtls-rs-sys/src/hook/digest/sha512.rs
+++ b/mbedtls-rs-sys/src/hook/digest/sha512.rs
@@ -117,6 +117,13 @@ mod alt {
 
     #[no_mangle]
     unsafe extern "C" fn mbedtls_sha512_free(ctx: *mut mbedtls_sha512_context) {
+        // MbedTLS contract: `mbedtls_sha512_free(NULL)` is documented as valid
+        // (see `digest_free` in `mbedtls-rs-sys/src/hook/digest.rs` for the
+        // full call-path rationale). Null-check before `algo(ctx)` because that
+        // helper dereferences `ctx` to read `is384`.
+        if ctx.is_null() {
+            return;
+        }
         digest_free(algo(ctx), ctx);
     }
 


### PR DESCRIPTION
MbedTLS upstream documents `mbedtls_sha{1,256,512}_free(NULL)` as a no-op
(sha1.h:76-82, sha256.h, sha512.h: "ctx ... may be NULL, in which case
this function returns immediately"). Our `MBEDTLS_SHA*_ALT` hook replaced
the upstream implementation with one that `.unwrap()`-panics on a NULL
pointer across the FFI boundary, diverging from the documented semantic.

No current MbedTLS 3.x caller passes NULL through: `mbedtls_md_free`
NULL-checks `ctx->md_ctx` at md.c:282, PSA passes `&operation->ctx` struct
fields, and the SHA self-tests pass `&ctx` stack vars. But any third-party
C linking these `#[no_mangle]` shims that calls `mbedtls_sha*_free(NULL)`,
or any future MbedTLS path that elects to pass NULL through, would land
here. The fix is one-liner per shim: `digest_free` (the shared helper)
`let Some(memory) = memory.as_mut() else { return; }` to no-op on NULL;
the SHA-256 / SHA-512 outer shims additionally NULL-check before the
`algo(ctx)` helper that dereferences `ctx` to read `is224` / `is384`. The
`digest_free` doc comment captures the upstream-caller survey for future
maintainers.

Drive-by: fix a `SHA1` -> `SHA-256` doc typo on `hook_sha256`.

Discussed in #156.
