### PR TITLE
Validate xtask target triple before deleting libs/<target> (F-49)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,7 +4,7 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 
 use clap::{Parser, Subcommand};
 
@@ -103,7 +103,33 @@ fn main() -> Result<()> {
         cargo_args,
     }) = args.command
     {
-        let libs_dst = sys_crate_root_path.join("libs").join(&target);
+        // Validate the CLI-supplied target triple before any path is built
+        // from it. The remaining destination paths (`libs/<target>`,
+        // `src/include/<target>.rs`) are then guaranteed to stay under
+        // `mbedtls-rs-sys/`; in particular the `remove_dir_all(libs_dst)` in
+        // `harvest` cannot escape via `../..`, an absolute path, or a `/`
+        // separator embedded in `target`.
+        validate_target_triple(&target).context("validating --target argument")?;
+
+        // Defense in depth: even with the validator above, canonicalize the
+        // libs root and assert that the join lands under it. Use `ensure!`
+        // instead of `debug_assert!` so the check survives release builds;
+        // `xtask` is typically run with `cargo run --release` where
+        // `debug_assert!` is elided.
+        let libs_root = sys_crate_root_path.join("libs");
+        fs::create_dir_all(&libs_root)
+            .with_context(|| format!("creating {}", libs_root.display()))?;
+        let canonical_libs_root = libs_root
+            .canonicalize()
+            .with_context(|| format!("canonicalizing {}", libs_root.display()))?;
+        let libs_dst = canonical_libs_root.join(&target);
+        ensure!(
+            libs_dst.starts_with(&canonical_libs_root),
+            "BUG: {} escaped {}",
+            libs_dst.display(),
+            canonical_libs_root.display(),
+        );
+
         let bindings_dst = sys_crate_root_path
             .join("src")
             .join("include")
@@ -346,4 +372,112 @@ fn harvest(out_dir: &Path, libs_dst: &Path, bindings_dst: &Path) -> Result<()> {
     info!("Copied bindings to {}", bindings_dst.display());
 
     Ok(())
+}
+
+/// Validates that `target` is a well-formed Rust target triple. Each `-`
+/// separated segment must match `[a-z0-9_.]+` and start with `[a-z0-9_]`
+/// (no leading dot); `..` is rejected anywhere; at least one `-`.
+///
+/// `libs/<target>` is later fed to `remove_dir_all`, so an unvalidated
+/// `target` containing `/`, `\`, an absolute prefix, or `..` could escape
+/// the `mbedtls-rs-sys/libs/` root. Real targets that must pass include
+/// `x86_64-unknown-linux-gnu`, `riscv32imc-unknown-none-elf`,
+/// `xtensa-esp32-none-elf`, `thumbv7em-none-eabihf`,
+/// `thumbv8m.main-none-eabi`, `thumbv8m.base-none-eabi`, and
+/// `wasm32-wasip1`.
+fn validate_target_triple(target: &str) -> Result<()> {
+    if target.is_empty() {
+        bail!("target triple is empty");
+    }
+    if target.len() > 64 {
+        bail!(
+            "target triple {target:?} too long ({} chars, max 64)",
+            target.len()
+        );
+    }
+    if target.contains("..") {
+        bail!("invalid target triple {target:?}: contains `..`");
+    }
+
+    let segs: Vec<&str> = target.split('-').collect();
+    if segs.len() < 2 {
+        bail!("invalid target triple {target:?}: must contain at least one `-`");
+    }
+    for seg in &segs {
+        if seg.is_empty() {
+            bail!("invalid target triple {target:?}: empty segment");
+        }
+        let bytes = seg.as_bytes();
+        let first = bytes[0];
+        if !(first.is_ascii_lowercase() || first.is_ascii_digit() || first == b'_') {
+            bail!("invalid target triple {target:?}: segment {seg:?} must start with [a-z0-9_]");
+        }
+        if !bytes.iter().all(|&b| is_target_byte(b)) {
+            bail!("invalid target triple {target:?}: segment {seg:?} must match [a-z0-9_.]+");
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+fn is_target_byte(b: u8) -> bool {
+    b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_' || b == b'.'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_target_triple;
+
+    #[test]
+    fn accepts_real_targets() {
+        for t in [
+            "x86_64-unknown-linux-gnu",
+            "aarch64-apple-darwin",
+            "riscv32imc-unknown-none-elf",
+            "riscv32imac-unknown-none-elf",
+            "xtensa-esp32-none-elf",
+            "xtensa-esp32s2-none-elf",
+            "xtensa-esp32s3-none-elf",
+            "thumbv7em-none-eabihf",
+            "thumbv8m.main-none-eabi",
+            "thumbv8m.main-none-eabihf",
+            "thumbv8m.base-none-eabi",
+            "wasm32-wasip1",
+        ] {
+            assert!(
+                validate_target_triple(t).is_ok(),
+                "rejected legit target {t:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_malformed() {
+        let too_long = "a-".repeat(40);
+        for bad in [
+            "../etc",
+            "../../etc/passwd",
+            "/etc/passwd",
+            ".",
+            "..",
+            "foo..bar",
+            ".foo-bar",
+            "foo-.bar",
+            "foo/bar",
+            "foo\\bar",
+            "FOO-BAR",
+            "foo bar",
+            "foo\nbar",
+            "-leading-dash",
+            "trailing-",
+            "single",
+            "",
+            too_long.as_str(),
+        ] {
+            assert!(
+                validate_target_triple(bad).is_err(),
+                "accepted malicious target {bad:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
`xtask gen` takes the Rust target triple as a free-form CLI string and
joins it onto `mbedtls-rs-sys/libs/<target>` and
`mbedtls-rs-sys/src/include/<target>.rs`. The first is later passed to
`fs::remove_dir_all` in `harvest` to clear stale artifacts. With no
validation, `xtask gen ../../etc` resolved `libs/../../etc` to `etc/`
relative to CWD and called `remove_dir_all` on it, and `xtask gen
/etc/passwd` made `Path::join` discard the prefix (absolute path
replaces) and called `remove_dir_all("/etc/passwd")`. A dev tool, so
low blast radius, but trivial to fix.

Add `validate_target_triple` and call it on the parsed `target` before
any path is built from it. Each `-`-separated segment must match
`[a-z0-9_.]+` and start with `[a-z0-9_]` (no leading dot); the
substring `..` is rejected anywhere; the whole string must have at
least one `-` and be at most 64 chars. The `.` is permitted in any
segment so real Armv8-M targets (`thumbv8m.main-none-eabi`,
`thumbv8m.main-none-eabihf`, `thumbv8m.base-none-eabi`) continue to
work; `..` is still rejected so traversal cannot smuggle through a
dotted segment.

As belt-and-braces, the libs root is canonicalized before the later
`remove_dir_all` and `ensure!` asserts the joined target still lives
under it. `ensure!` (not `debug_assert!`) so the check survives
release builds, since `xtask` is typically run via `cargo run
--release`.

Inline tests cover every real target the upstream CI matrix builds
(`x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, all the riscv32
/ xtensa / thumbv7 / thumbv8m / wasm32-wasip1 leaves) plus 18
rejection cases (`..` traversal, absolute paths, `/` and `\`
separators, uppercase, spaces, control chars, leading-dash,
trailing-dash, single-segment, empty, and over-length). Manual smoke
verified: `xtask gen ../../etc` and `xtask gen /etc/passwd` both
exit non-zero with a clear `invalid target triple` message before
any filesystem mutation; `xtask gen thumbv8m.main-none-eabi`
proceeds into the existing build path unchanged.

Refs: CODE_REVIEW.md sections 249 and 415.
