### PR TITLE
Centralize all dependencies to the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,35 @@ members = [
 ]
 
 exclude = ["examples", "xtask"]
+
+[workspace.dependencies]
+defmt = { version = "1", default-features = false }
+log = { version = "0.4", default-features = false }
+enumset = { version = "1", default-features = false }
+digest = { version = "0.10", default-features = false }
+sha1 = { version = "0.10", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+time = { version = "0.3", default-features = false }
+critical-section = { version = "1", default-features = false }
+
+embedded-io = { version = "0.7", default-features = false }
+embedded-io-async = { version = "0.7", default-features = false }
+rand_core = { version = "0.10.1", default-features = false }
+
+# For esp-hal hook impls
+esp-hal = { version = "~1.1.0", default-features = false }
+crypto-bigint = { version = "0.5.3", default-features = false }
+
+# For embassy timer hook impl
+embassy-time = {version = "0.5", default-features = false}
+
+mbedtls-rs-sys = { version = "0.1", path = "mbedtls-rs-sys", default-features = false }
+
+# Build dependencies
+anyhow = "1"
+bindgen = "0.72"
+env_logger = "0.11"
+cmake = "0.1.52"
+cc = "1.1"
+fs_extra = "1.3"
+embuild = "0.33"

--- a/examples/std/.cargo/config.toml
+++ b/examples/std/.cargo/config.toml
@@ -2,3 +2,6 @@
 runner = "espflash flash --baud 921600 --monitor"
 linker = "ldproxy"
 rustflags = ["--cfg", "espidf_time64"]
+
+[env]
+RUST_LOG="info"

--- a/mbedtls-rs-sys/Cargo.toml
+++ b/mbedtls-rs-sys/Cargo.toml
@@ -261,23 +261,23 @@ kex-ecjpake = []
 platform-zeroize-alt = []
 
 [dependencies]
-defmt = { version = "1", optional = true }
-log = { version = "0.4", optional = true }
-enumset = { version = "1", default-features = false }
+defmt = { workspace = true, optional = true }
+log = { workspace = true, default-features = false, optional = true }
+enumset = { workspace = true, default-features = false }
 # For hooking
-digest = { version = "0.10", default-features = false }
-sha1 = { version = "0.10", default-features = false }
+digest = { workspace = true, default-features = false }
+sha1 = { workspace = true, default-features = false }
 # For some reason, `soft` results in enormous slowdowns on xtensa and riscv32
-sha2 = { version = "0.10", default-features = false, features = ["force-soft-compact"] }
-time = { version = "0.3", default-features = false, optional = true }
-critical-section = "1"
+sha2 = { workspace = true, default-features = false, features = ["force-soft-compact"] }
+time = { workspace = true, default-features = false, optional = true }
+critical-section = { workspace = true }
 
 # For esp-hal hook impls
-esp-hal = { version = "~1.1.0", features = ["unstable"], optional = true }
-crypto-bigint = { version = "0.5.3", default-features = false, features = ["extra-sizes"], optional = true }
+esp-hal = { workspace = true, features = ["unstable"], optional = true }
+crypto-bigint = { workspace = true, default-features = false, features = ["extra-sizes"], optional = true }
 
 # For embassy timer hook impl
-embassy-time = {version = "0.5", optional = true}
+embassy-time = {workspace = true, optional = true }
 
 # ESP-IDF: The mbedtls lib distributed with ESP-IDF is used
 # All other platforms: mbedtls libs and bindings are created on the fly
@@ -285,12 +285,12 @@ embassy-time = {version = "0.5", optional = true}
 esp-idf-sys = { version = "0.37", default-features = false }
 
 [build-dependencies]
-anyhow = "1"
-bindgen = "0.72"
-enumset = "1"
-env_logger = "0.11"
-log = "0.4"
-cmake = "0.1.52"
-cc = "1.1"
-fs_extra = "1.3"
-embuild = "0.33"
+anyhow = { workspace = true, default-features = true }
+bindgen = { workspace = true, default-features = true }
+enumset = { workspace = true, default-features = true }
+env_logger = { workspace = true, default-features = true }
+log = { workspace = true, default-features = true }
+cmake = { workspace = true, default-features = true }
+cc = { workspace = true, default-features = true }
+fs_extra = { workspace = true, default-features = true }
+embuild = { workspace = true, default-features = true }

--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -161,7 +161,7 @@ embassy-time = ["mbedtls-rs-sys/embassy-time"]
 # under `--no-default-features` (a coherent minimal EC TLS 1.2/1.3 stack: the SSL
 # engine, X.509 + PK + PEM parse, ECDHE-ECDSA over P-256, AES-GCM, SHA-256, HKDF,
 # CTR-DRBG + entropy). Consumer-selected bundles/leaves are unioned on top.
-mbedtls-rs-sys = { path = "../mbedtls-rs-sys", default-features = false, features = [
+mbedtls-rs-sys = { workspace = true, default-features = false, features = [
     "tls-engine", "tls-core", "tls-client", "tls-server",
     "tls-proto-tls12", "tls-proto-tls13",
     "kex-ecdhe-ecdsa",
@@ -170,10 +170,10 @@ mbedtls-rs-sys = { path = "../mbedtls-rs-sys", default-features = false, feature
     "curve-secp256r1",
     "drbg-ctr", "entropy", "base64", "pem-parse", "x509-parse",
 ] }
-defmt = { version = "1", optional = true }
-log = { version = "0.4", default-features = false, optional = true }
-embedded-io = { version = "0.7" }
-embedded-io-async = { version = "0.7" }
-enumset = { version = "1", default-features = false }
-rand_core = "0.10.1"
-critical-section = "1"
+defmt = { workspace = true, optional = true }
+log = { workspace = true, default-features = false, optional = true }
+embedded-io = { workspace = true }
+embedded-io-async = { workspace = true }
+enumset = { workspace = true, default-features = false }
+rand_core = { workspace = true }
+critical-section = { workspace = true }


### PR DESCRIPTION
The absolute minimum was to specify the version of the `mbedtls-sys`  dependency in `mbedtls-rs`'s `Cargo.toml`, but I think centralizing the dependencies to the workspace file is actually not a bad idea.

Sadly, we cannot extend this idea to the `examples/*` and `xtask` crates, as these are not workspace members for good reasons.