### PR TITLE
Final fixes for the crates.io release

### DIFF
--- a/.github/workflows/publish-crate-dry-run.yml
+++ b/.github/workflows/publish-crate-dry-run.yml
@@ -20,16 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_toolchain }}
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
-      - name: Setup | Set default toolchain
-        run: rustup default ${{ env.rust_toolchain }}
+          components: rust-src
       - name: Build | Publish Dry Run
         run: cd "${{ github.event.inputs.crate }}"; cargo publish --dry-run
+      - name: Get the crate version from cargo
+        run: |
+          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{github.event.inputs.crate}}\") | .version")
+          echo "crate_version=$version" >> $GITHUB_ENV
+          echo "${{github.event.inputs.crate}} version: $version"
+      - name: Tag the new release (dry run)
+        run: |
+          echo "Would create tag: ${{github.event.inputs.crate}}-v${{env.crate_version}}"
+          echo "Would use message: Release ${{github.event.inputs.crate}} v${{env.crate_version}}"

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -18,20 +18,32 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    # `contents: write` is required so the "Tag the new release" step can push
+    # the git tag. The default GITHUB_TOKEN is read-only for repos/orgs whose
+    # default workflow permissions are "read", which is why tagging fails today.
+    permissions:
+      contents: write
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_toolchain }}
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain ${{ env.rust_toolchain }}-x86_64-unknown-linux-gnu
-      - name: Setup | Set default toolchain
-        run: rustup default ${{ env.rust_toolchain }}
+          components: rust-src
       - name: Login
         run: cargo login ${{ secrets.crates_io_token }}
       - name: Build | Publish
         run: cd "${{ github.event.inputs.crate }}"; cargo publish
+      - name: Get the crate version from cargo
+        run: |
+          version=$(cargo metadata --format-version=1 --no-deps | jq -r ".packages[] | select(.name == \"${{github.event.inputs.crate}}\") | .version")
+          echo "crate_version=$version" >> $GITHUB_ENV
+          echo "${{github.event.inputs.crate}} version: $version"
+      - name: Tag the new release
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{github.event.inputs.crate}}-v${{env.crate_version}}
+          message: "Release ${{github.event.inputs.crate}} v${{env.crate_version}}"

--- a/mbedtls-rs-sys/Cargo.toml
+++ b/mbedtls-rs-sys/Cargo.toml
@@ -8,6 +8,8 @@ rust-version = "1.84"
 description = "Raw Rust bindings of the MbedTLS library"
 repository = "https://github.com/esp-rs/mbedtls-rs"
 readme = "README.md"
+keywords = ["mbedtls", "tls", "embedded", "no-std", "ffi"]
+categories = ["cryptography", "embedded", "no-std", "external-ffi-bindings", "network-programming"]
 exclude = ["*.pyc", "mbedtls/framework", "mbedtls/programs", "mbedtls/tests"]
 
 [lib]

--- a/mbedtls-rs-sys/gen/builder.rs
+++ b/mbedtls-rs-sys/gen/builder.rs
@@ -511,6 +511,12 @@ impl CMakeConfigurer {
         let mut config = Config::new(&self.project_path);
 
         config
+            // MbedTLS's CMake build runs Python helper scripts (e.g. to locate the
+            // `framework` directory). Python writes `__pycache__/*.pyc` caches next
+            // to those scripts, i.e. inside the crate source tree. `cargo publish`
+            // verifies the extracted package was not modified by build.rs and aborts
+            // when it finds those stray `.pyc` files, so disable bytecode caching.
+            .env("PYTHONDONTWRITEBYTECODE", "1")
             // ... or else the build would fail with `arm-none-eabi-gcc` when testing the compiler
             .define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY")
             .define("CMAKE_EXPORT_COMPILE_COMMANDS", "ON")

--- a/mbedtls-rs/Cargo.toml
+++ b/mbedtls-rs/Cargo.toml
@@ -7,6 +7,8 @@ rust-version = "1.84"
 description = "Rust library implementing transparent TLS encryption/decryption for IO streams with MbedTLS"
 repository = "https://github.com/esp-rs/mbedtls-rs"
 readme = "README.md"
+keywords = ["mbedtls", "tls", "ssl", "embedded", "no-std"]
+categories = ["cryptography", "embedded", "no-std", "network-programming"]
 
 [lib]
 harness = false


### PR DESCRIPTION
A set of small fixes prior to publishing. Most notable addition - the tagging process at the end of the publish action.