### PR TITLE
Fix the crate build when defmt is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Check - defmt
+        run: cargo check -p mbedtls-rs --features defmt
+
       # Host-only test of the ESP exp_mod routing logic (`_route-test` mounts
       # `backend::esp::exp_mod_route` without `esp-hal`); not part of the
       # default feature set, so it needs its own invocation.

--- a/mbedtls-rs-sys/src/hook/aes.rs
+++ b/mbedtls-rs-sys/src/hook/aes.rs
@@ -360,7 +360,8 @@ mod alt {
     // the `WorkArea` docs in `src/hook.rs`); hardware backends embedding
     // `RustCryptoAesState` as a software escape hatch are covered by the
     // same bound.
-    const _: () = assert!(
+    // `core::assert!`, not the crate `assert!` (whose `defmt` variant is not const-callable)
+    const _: () = core::assert!(
         core::mem::size_of::<Option<RustCryptoAesState>>() + 16
             <= crate::MBEDTLS_AES_ALT_WORK_AREA_SIZE as usize,
         "The RustCrypto AES state does not fit the AES hook work area"

--- a/mbedtls-rs-sys/src/hook/digest/sha1.rs
+++ b/mbedtls-rs-sys/src/hook/digest/sha1.rs
@@ -54,7 +54,8 @@ mod alt {
     // offset (up to 15 bytes of emplacement waste at under-aligned opaque
     // storage — see `sha256.rs` for the
     // full rationale).
-    const _: () = assert!(
+    // `core::assert!`, not the crate `assert!` (whose `defmt` variant is not const-callable)
+    const _: () = core::assert!(
         core::mem::size_of::<Option<sha1::Sha1>>() + 16
             <= crate::MBEDTLS_SHA1_ALT_WORK_AREA_SIZE as usize,
         "The RustCrypto SHA-1 state does not fit the SHA-1 hook work area"

--- a/mbedtls-rs-sys/src/hook/digest/sha256.rs
+++ b/mbedtls-rs-sys/src/hook/digest/sha256.rs
@@ -81,12 +81,13 @@ mod alt {
     // casts support) — hence the `+ 16`. Registered hardware backends emplace
     // their own types and are covered by the runtime fit check in
     // `WorkArea::cast_mut_maybe`.
-    const _: () = assert!(
+    // `core::assert!`, not the crate `assert!` (whose `defmt` variant is not const-callable)
+    const _: () = core::assert!(
         core::mem::size_of::<Option<sha2::Sha256>>() + 16
             <= crate::MBEDTLS_SHA256_ALT_WORK_AREA_SIZE as usize,
         "The RustCrypto SHA-256 state does not fit the SHA-256 hook work area"
     );
-    const _: () = assert!(
+    const _: () = core::assert!(
         core::mem::size_of::<Option<sha2::Sha224>>() + 16
             <= crate::MBEDTLS_SHA256_ALT_WORK_AREA_SIZE as usize,
         "The RustCrypto SHA-224 state does not fit the SHA-256 hook work area"

--- a/mbedtls-rs-sys/src/hook/digest/sha512.rs
+++ b/mbedtls-rs-sys/src/hook/digest/sha512.rs
@@ -77,12 +77,13 @@ mod alt {
     // The work area must be able to host the fallback's state at *any* runtime
     // offset (up to 15 bytes of emplacement waste at under-aligned opaque storage — see `sha256.rs` for the
     // full rationale).
-    const _: () = assert!(
+    // `core::assert!`, not the crate `assert!` (whose `defmt` variant is not const-callable)
+    const _: () = core::assert!(
         core::mem::size_of::<Option<sha2::Sha512>>() + 16
             <= crate::MBEDTLS_SHA512_ALT_WORK_AREA_SIZE as usize,
         "The RustCrypto SHA-512 state does not fit the SHA-512 hook work area"
     );
-    const _: () = assert!(
+    const _: () = core::assert!(
         core::mem::size_of::<Option<sha2::Sha384>>() + 16
             <= crate::MBEDTLS_SHA512_ALT_WORK_AREA_SIZE as usize,
         "The RustCrypto SHA-384 state does not fit the SHA-512 hook work area"


### PR DESCRIPTION
Subject says it all. We should use `core::assert` instead of `defmt::assert` as these asserts are actually compile-time errors.